### PR TITLE
Port loglevel and fix installation instructions

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: openldap
 home: https://www.openldap.org
-version: 2.0.1
+version: 2.0.2
 appVersion: 2.4.47
 description: Community developed LDAP software
 icon: http://www.openldap.org/images/headers/LDAPworm.gif

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ This chart will do the following:
 To install the chart with the release name `my-release`:
 
 ```bash
-$ helm install --name my-release stable/openldap
+$ git clone https://github.com/jp-gouin/helm-openldap.git
+$ cd helm-openldap
+$ helm install openldap .
 ```
 
 ## Configuration
@@ -44,6 +46,7 @@ The following table lists the configurable parameters of the openldap chart and 
 | `service.sslLdapPort`              | External service port for SSL+LDAP                                                                                                        | `636`               |
 | `service.type`                     | Service type                                                                                                                              | `ClusterIP`         |
 | `env`                              | List of key value pairs as env variables to be sent to the docker image. See https://github.com/osixia/docker-openldap for available ones | `[see values.yaml]` |
+| `logLevel`                         | Set the container log level. Valid values: `none`, `error`, `warning`, `info`, `debug`, `trace`                                           | `info`              |
 | `tls.enabled`                      | Set to enable TLS/LDAPS with custom certificate - should also set `tls.secret`                                                                                    | `false`             |
 | `tls.secret`                       | Secret containing TLS cert and key (eg, generated via cert-manager)                                                                       | `""`                |
 | `tls.CA.enabled`                   | Set to enable custom CA crt file - should also set `tls.CA.secret`                                                                        | `false`             |

--- a/templates/statefullset.yaml
+++ b/templates/statefullset.yaml
@@ -39,8 +39,12 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - -l
+            - {{ .Values.logLevel }}
 {{- if .Values.customLdifFiles }}
           args: [--copy-service]
+            - --copy-service
 {{- end }}
           ports:
             - name: ldap-port

--- a/values.yaml
+++ b/values.yaml
@@ -126,6 +126,11 @@ test:
   image:
     repository: dduportal/bats
     tag: 0.4.0
+
+# Set the container log level
+# Valid log levels: none, error, warning, info (default), debug, trace
+logLevel: info
+
 ltb-passwd:
   enabled : true
   ingress:


### PR DESCRIPTION
This PR ports the recent PR to upstream, which enables custom loglevels to be set in values.yaml.
This is of great importance because it makes it easier for all of us to work on this port.

It also updates the readme with actual install instructions.