### PR TITLE
Update container, Fix replication, port log-level and update readme

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: openldap
 home: https://www.openldap.org
-version: 2.0.1
+version: 2.0.2
 appVersion: 2.4.47
 description: Community developed LDAP software
 icon: http://www.openldap.org/images/headers/LDAPworm.gif

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ This chart will do the following:
 To install the chart with the release name `my-release`:
 
 ```bash
-$ helm install --name my-release stable/openldap
+$ git clone https://github.com/jp-gouin/helm-openldap.git
+$ cd helm-openldap
+$ helm install openldap .
 ```
 
 ## Configuration
@@ -44,6 +46,7 @@ The following table lists the configurable parameters of the openldap chart and 
 | `service.sslLdapPort`              | External service port for SSL+LDAP                                                                                                        | `636`               |
 | `service.type`                     | Service type                                                                                                                              | `ClusterIP`         |
 | `env`                              | List of key value pairs as env variables to be sent to the docker image. See https://github.com/osixia/docker-openldap for available ones | `[see values.yaml]` |
+| `logLevel`                         | Set the container log level. Valid values: `none`, `error`, `warning`, `info`, `debug`, `trace`                                           | `info`              |
 | `tls.enabled`                      | Set to enable TLS/LDAPS with custom certificate - should also set `tls.secret`                                                                                    | `false`             |
 | `tls.secret`                       | Secret containing TLS cert and key (eg, generated via cert-manager)                                                                       | `""`                |
 | `tls.CA.enabled`                   | Set to enable custom CA crt file - should also set `tls.CA.secret`                                                                        | `false`             |
@@ -60,6 +63,7 @@ The following table lists the configurable parameters of the openldap chart and 
 | `test.image.repository`            | Test container image requires bats framework                                                                                              | `dduportal/bats`    |
 | `test.image.tag`                   | Test container tag                                                                                                                        | `0.4.0`             |
 | `replication.enabled`              | Enable the multi-master replication | `true` |
+| `replication.clusterName`          | Set the clustername for replication | "cluster.local" |
 | `phpldapadmin.enabled`             | Enable the deployment of PhpLdapAdmin | `true`|
 | `phpldapadmin.ingress`             | Ingress of Phpldapadmin | `{}` |
 | `phpldapadmin.env`  | Environment variables for PhpldapAdmin| `{}` |

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -52,9 +52,11 @@ Generate replication services list
 */}}
 {{- define "replicalist" -}}
 {{- $name := (include "openldap.fullname" .) }}
+{{- $namespace := .Release.Namespace }}
+{{- $cluster := .Values.replication.clusterName }}
 {{- $nodeCount := .Values.replicaCount | int }}
   {{- range $index0 := until $nodeCount -}}
     {{- $index1 := $index0 | add1 -}}
-'ldap://{{ $name }}-{{ $index0 }}.{{ $name }}-headless'{{ if ne $index1 $nodeCount }},{{ end }}
+'ldap://{{ $name }}-{{ $index0 }}.{{ $name }}-headless.{{ $namespace }}.svc.{{ $cluster }}'{{ if ne $index1 $nodeCount }},{{ end }}
   {{- end -}}
 {{- end -}}

--- a/templates/statefullset.yaml
+++ b/templates/statefullset.yaml
@@ -39,8 +39,11 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - -l
+            - {{ .Values.logLevel }}
 {{- if .Values.customLdifFiles }}
-          args: [--copy-service]
+            - --copy-service
 {{- end }}
           ports:
             - name: ldap-port
@@ -67,8 +70,6 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: HOSTNAME
-              value: $(POD_NAME).{{ template "openldap.fullname" . }}-headless
           {{- if .Values.tls.enabled }}
             - name: LDAP_TLS_CRT_FILENAME
               value: tls.crt

--- a/templates/svc-headless.yaml
+++ b/templates/svc-headless.yaml
@@ -15,4 +15,6 @@ spec:
   clusterIP: None
   selector:
     app: {{ template "openldap.fullname" . }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name }}  
+  type: ClusterIP
+  sessionAffinity: None

--- a/values.yaml
+++ b/values.yaml
@@ -92,7 +92,10 @@ env:
   # 01-default-users.ldif: |-
     # Predefine users here
 replication:
-  enabled: true    
+  enabled: true  
+  # Enter the name of your cluster, defaults to "cluster.local"
+  clusterName: "cluster.local"
+
 ## Persist data to a persistent volume
 persistence:
   enabled: true
@@ -143,10 +146,10 @@ ltb-passwd:
     hosts:
     - "ssl-ldap2.example"
   ldap:
-    server: ldap://openldap.openldap
     searchBase: dc=example,dc=org
     binduserSecret: openldaptest
     bindDN: cn=admin,dc=example,dc=org
+    server: ldap://openldap
     bindPWKey: LDAP_ADMIN_PASSWORD
 
 phpldapadmin:
@@ -159,7 +162,7 @@ phpldapadmin:
     hosts:
     - phpldapadmin.example
   env:
-    PHPLDAPADMIN_LDAP_HOSTS: openldap.openldap
+    PHPLDAPADMIN_LDAP_HOSTS: openldap
  # TODO make it works
  #     "#PYTHON2BASH:
  #       [{'openldap.openldap': 

--- a/values.yaml
+++ b/values.yaml
@@ -18,12 +18,14 @@ strategy: {}
 image:
   # From repository https://github.com/osixia/docker-openldap
   repository: osixia/openldap
-  tag: stable
+  tag: 1.4.0
   pullPolicy: Always
   pullSecret: harbor
 
 # Spcifies an existing secret to be used for admin and config user passwords
-existingSecret: ""
+# existingSecret: ""
+
+logLevel: info
 
 # settings for enabling TLS with custom certificate
 tls:
@@ -126,6 +128,11 @@ test:
   image:
     repository: dduportal/bats
     tag: 0.4.0
+
+# Set the container log level
+# Valid log levels: none, error, warning, info (default), debug, trace
+logLevel: info
+
 ltb-passwd:
   enabled : true
   ingress:


### PR DESCRIPTION
This is a cleanup, update and fix patch. To ensure all features actually work.
(newsflash: In a lot of cases replication isn't working very well)

As there are replication fixes in v1.4.0 of the container, I updated and tested the new container.
I also patched the bug currently causing many of us not to be able to use replication. The host list for replication NEEDS the **FULL** fqdn. So I added a field to set the cluster name and changed the template to ensure we generate the complete fqdn for creating the replication host list.

I also ported the recently added feature to set the loglevel from upstream, added an actually working installation guide to the readme.

TLDR: This should prevent the FLOOD of replication issues that plaguing this build and are being filed in both the container and helm-chart upstreams