### PR TITLE
Add service.omitClusterIP parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The following table lists the configurable parameters of the openldap chart and 
 | `podAnnotations`                   | Annotations to add to the pod                                                                                                             | `{}`                |
 | `existingSecret`                   | Use an existing secret for admin and config user passwords                                                                                | `""`                |
 | `service.annotations`              | Annotations to add to the service                                                                                                         | `{}`                |
+| `service.omitClusterIP`            | Do not set a ClusterIP. If set to `true` this will ignore `service.clusterIP`                                                             | `false`             |
 | `service.clusterIP`                | IP address to assign to the service                                                                                                       | `""`                |
 | `service.externalIPs`              | Service external IP addresses                                                                                                             | `[]`                |
 | `service.ldapPort`                 | External service port for LDAP                                                                                                            | `389`               |

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -15,7 +15,9 @@ metadata:
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
 spec:
+{{- if not .Values.service.omitClusterIP }}
   clusterIP: {{ .Values.service.clusterIP | quote }}
+{{- end }}
 {{- if .Values.service.externalIPs }}
   externalIPs:
 {{ toYaml .Values.service.externalIPs | indent 4 }}

--- a/values.yaml
+++ b/values.yaml
@@ -41,6 +41,7 @@ extraLabels: {}
 podAnnotations: {}
 service:
   annotations: {}
+  omitClusterIP: true
   clusterIP: ""
 
   ldapPort: 389
@@ -168,4 +169,4 @@ phpldapadmin:
  #             [{'bind_id': 'cn=admin,dc=example,dc=org'}]
  #           }]
  #       }]"
-     
+

--- a/values.yaml
+++ b/values.yaml
@@ -41,7 +41,7 @@ extraLabels: {}
 podAnnotations: {}
 service:
   annotations: {}
-  omitClusterIP: true
+  omitClusterIP: false
   clusterIP: ""
 
   ldapPort: 389


### PR DESCRIPTION
Hey I noticed you could not issue a helm upgrade with this chart if clusterIP was left to the default value of `""`. This should fix it.

Ref: https://github.com/helm/helm/issues/6378#issuecomment-557746499