### PR TITLE
Fix StatefulSet update strategy

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
     version: 0.1.x
     condition: phpldapadmin.enabled
 home: https://www.openldap.org
-version: 2.1.0
+version: 2.1.1
 appVersion: 2.4.47
 description: Community developed LDAP software
 icon: https://raw.githubusercontent.com/jp-gouin/helm-openldap/master/logo.png

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -18,7 +18,7 @@ keywords:
   - iam-stack
   - high availability 
 sources:
-  - https://github.com/kubernetes/charts
+  - https://github.com/jp-gouin/helm-openldap
 maintainers:
   - name: Jean-Philippe Gouin
     email: jp-gouin@hotmail.fr

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The following table lists the configurable parameters of the openldap chart and 
 | Parameter                          | Description                                                                                                                               | Default             |
 | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
 | `replicaCount`                     | Number of replicas                                                                                                                        | `3`                 |
-| `strategy`                         | Deployment strategy                                                                                                                       | `{}`                |
+| `updateStrategy`                   | StatefulSet update strategy                                                                                                               | `{}`                |
 | `image.repository`                 | Container image repository                                                                                                                | `osixia/openldap`   |
 | `image.tag`                        | Container image tag                                                                                                                       | `1.1.10`            |
 | `image.pullPolicy`                 | Container pull policy                                                                                                                     | `IfNotPresent`      |

--- a/templates/statefullset.yaml
+++ b/templates/statefullset.yaml
@@ -12,9 +12,9 @@ metadata:
 {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
-{{- if .Values.strategy }}
-  strategy:
-{{ toYaml .Values.strategy | indent 4 }}
+{{- if .Values.updateStrategy }}
+  updateStrategy:
+{{ toYaml .Values.updateStrategy | indent 4 }}
 {{- end }}
   selector:
     matchLabels:

--- a/templates/statefullset.yaml
+++ b/templates/statefullset.yaml
@@ -139,8 +139,10 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- if .Values.image.pullSecret }}
       imagePullSecrets: 
         - name: {{ .Values.image.pullSecret }}
+    {{- end }}
       volumes:
 {{- if .Values.customLdifFiles }}
         - name: custom-ldif-files

--- a/values.yaml
+++ b/values.yaml
@@ -3,18 +3,26 @@
 # Declare variables to be passed into your templates.
 
 replicaCount: 3
-# Define deployment strategy - IMPORTANT: use rollingUpdate: null when use Recreate strategy.
-# It prevents from merging with existing map keys which are forbidden.
-strategy: {}
+updateStrategy: {}
+  # When a StatefulSet's .spec.updateStrategy.type is set to OnDelete, 
+  # the StatefulSet controller will not automatically update the Pods
+  # in a StatefulSet. Users must manually delete Pods to cause the
+  # controller to create new Pods that reflect modifications made
+  # to a StatefulSet's .spec.template.
+  # 
+  # type: OnDelete
+  # 
+  # or
+  # 
+  # When a StatefulSet's .spec.updateStrategy.type is set to RollingUpdate,
+  # the StatefulSet controller will delete and recreate each Pod in the StatefulSet.
+  # It will proceed in the same order as Pod termination (from the largest ordinal 
+  # to the smallest), updating each Pod one at a time. It will wait until an updated
+  # Pod is Running and Ready prior to updating its predecessor.
+  # 
   # type: RollingUpdate
   # rollingUpdate:
-  #   maxSurge: 1
-  #   maxUnavailable: 0
-  #
-  # or
-  #
-  # type: Recreate
-  # rollingUpdate: null
+  #   partition: 1
 image:
   # From repository https://github.com/osixia/docker-openldap
   repository: osixia/openldap

--- a/values.yaml
+++ b/values.yaml
@@ -28,6 +28,7 @@ image:
   repository: osixia/openldap
   tag: 1.4.0
   pullPolicy: Always
+  # pullSecret: harbor
 
 # Set the container log level
 # Valid log levels: none, error, warning, info (default), debug, trace

--- a/values.yaml
+++ b/values.yaml
@@ -28,7 +28,6 @@ image:
   repository: osixia/openldap
   tag: 1.4.0
   pullPolicy: Always
-  pullSecret: harbor
 
 # Set the container log level
 # Valid log levels: none, error, warning, info (default), debug, trace


### PR DESCRIPTION
- StatefulSets do not have `strategy` parameter, instead there is `updateStrategy` one for that purposes.
- No need to override/unset default imagePullSecrets anymore (useful when pull secret is provided in the namespace)