### PR TITLE
Fix pod anti affinity using wrong labels

### DIFF
--- a/templates/statefullset.yaml
+++ b/templates/statefullset.yaml
@@ -133,8 +133,8 @@ spec:
           - topologyKey: kubernetes.io/hostname
             labelSelector:
               matchLabels:
-                app.kubernetes.io/component: {{ .Release.Name }}
-                app.kubernetes.io/instance: {{ .Release.Name }}
+                app: {{ template "openldap.fullname" . }}
+                release: {{ .Release.Name }}
     {{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}


### PR DESCRIPTION
First of all I want to thank you very much for this Helm chart of OpenLDAP. I'm using it for a long time now and it's working great :+1: 

However I noticed that the `podAntiAffinity` was not working correctly, and I found out that it tries to match to wrong labels instead of the ones actually used in Line 34-35.

Trying to get that functionality back with this PR :)