### PR TITLE
Add startup probe and allow probe modification

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ The following table lists the configurable parameters of the openldap chart and 
 | `persistence.existingClaim`        | Add existing Volumes Claim. | `<unset>`           |
 | `persistence.accessMode`           | Access mode for PersistentVolumes                                                                                                         | `ReadWriteOnce`     |
 | `persistence.size`                 | PersistentVolumeClaim storage size                                                                                                        | `8Gi`               |
+| `livenessProbe`                    | Liveness probe configuration                                                                                                              | `[see values.yaml]` |
+| `readinessProbe`                   | Readiness probe configuration                                                                                                             | `[see values.yaml]` |
+| `startupProbe`                     | Startup probe configuration                                                                                                               | `[see values.yaml]` |
 | `resources`                        | Container resource requests and limits in yaml                                                                                            | `{}`                |
 | `test.enabled`                     | Conditionally provision test resources                                                                                                    | `false`             |
 | `test.image.repository`            | Test container image requires bats framework                                                                                              | `dduportal/bats`    |

--- a/templates/statefullset.yaml
+++ b/templates/statefullset.yaml
@@ -106,18 +106,36 @@ spec:
             - name: LDAP_TLS_CA_CRT_FILENAME
               value: ca.crt
           {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             tcpSocket:
               port: ldap-port
-            initialDelaySeconds: 20
-            periodSeconds: 10
-            failureThreshold: 10
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             tcpSocket:
               port: ldap-port
-            initialDelaySeconds: 20
-            periodSeconds: 10
-            failureThreshold: 10
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            tcpSocket:
+              port: ldap-port
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.startupProbe.successThreshold }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/values.yaml
+++ b/values.yaml
@@ -129,6 +129,30 @@ persistence:
     - ReadWriteOnce
   size: 8Gi
 
+## Configure extra options for liveness, readiness, and startup probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 20
+  periodSeconds: 10
+  timeoutSeconds: 1
+  successThreshold: 1
+  failureThreshold: 10
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 20
+  periodSeconds: 10
+  timeoutSeconds: 1
+  successThreshold: 1
+  failureThreshold: 10
+startupProbe:
+  enabled: false
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  timeoutSeconds: 1
+  successThreshold: 1
+  failureThreshold: 30
+
 resources: {}
  # requests:
  #   cpu: "100m"


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR adds two new features:
1.  Liveness and readiness probes are now customizable with respect to timing and thresholds and they can be disabled.
2. A startup probe is added as an option (disabled by default).

The reason for this PR is to allow adjustments in environments where it takes longer than 2 minutes for the initial startup (or any other requirements around timing of probes and thresholds). Sometimes the DH param generation takes longer than the `initialDelaySeconds + periodSeconds * failureThreshold` putting the pod into a crash loop.

This also allows the liveness probe to be easily disabled when debugging a startup error to prevent pod restarts.

This is a new capability, but it is functionally identical to the existing behavior in the default setting.

### Pre-submission checklist:

* [X] Did you explain what problem does this PR solve? Or what new features have been added?
* [X] Have you updated the readme?
* [X] Is this PR backward compatible? **If it is not backward compatible, please discuss open a ticket first**