### PR TITLE
Add hint which secret key is expected for existingSecret + minor docs

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -34,9 +34,6 @@ image:
 # Valid log levels: none, error, warning, info (default), debug, trace
 logLevel: info
 
-# Specifies an existing secret to be used for admin and config user passwords
-existingSecret: ""
-
 # Settings for enabling TLS with custom certificate
 # need a secret with tls.crt, tls.key and ca.crt keys with associated files
 # Ref: https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/#create-a-secret
@@ -107,8 +104,10 @@ env:
  LDAP_TLS_CIPHER_SUITE: "NORMAL"
 
   
+# Specifies an existing secret to be used for admin and config user passwords. The expected key are LDAP_ADMIN_PASSWORD and LDAP_CONFIG_PASSWORD.
+existingSecret: ""
 
-# Default Passwords to use, stored as a secret.
+# Default Passwords to use, stored as a secret. Not used if existingSecret is set.
 # You can override these at install time with
 # helm install openldap --set openldap.adminPassword=<passwd>,openldap.configPassword=<passwd>
 adminPassword: Not@SecurePassw0rd


### PR DESCRIPTION
### What this PR does / why we need it:
Makes the usage a little simpler without backtracking it to secrets.yml

 - move existingSecret to adminPassword / configPassword since they logically go together and are mutually exclusive
 - add docs to adminPassword / configPassword that they are ignored if existingSecret if used

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you updated the readme?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss open a ticket first**