### PR TITLE
Make it possible to disable the service creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,17 @@
 # OpenLDAP Helm Chart
 
 ## Prerequisites Details
-* Kubernetes 1.8+
-* PV support on the underlying infrastructure
+
+- Kubernetes 1.8+
+- PV support on the underlying infrastructure
 
 ## Chart Details
+
 This chart will do the following:
 
-* Instantiate 3 instances of OpenLDAP server with multi-master replication
-* A phpldapadmin to administrate the OpenLDAP server
-* ltb-passwd for self service password
+- Instantiate 3 instances of OpenLDAP server with multi-master replication
+- A phpldapadmin to administrate the OpenLDAP server
+- ltb-passwd for self service password
 
 ## TL;DR
 
@@ -40,31 +42,32 @@ The following table lists the configurable parameters of the openldap chart and 
 | `extraLabels`                      | Labels to add to the Resources                                                                                                            | `{}`                |
 | `podAnnotations`                   | Annotations to add to the pod                                                                                                             | `{}`                |
 | `existingSecret`                   | Use an existing secret for admin and config user passwords                                                                                | `""`                |
+| `service.enabled`                  | Create a load-balancer service                                                                                                            | `true`              |
 | `service.annotations`              | Annotations to add to the service                                                                                                         | `{}`                |
 | `service.externalIPs`              | Service external IP addresses                                                                                                             | `[]`                |
 | `service.ldapPort`                 | External service port for LDAP                                                                                                            | `389`               |
-| `service.ldapPortNodePort`                 | Nodeport of External service port for LDAP if service.type is NodePort                                                                                                            | `nil`               |
+| `service.ldapPortNodePort`         | Nodeport of External service port for LDAP if service.type is NodePort                                                                    | `nil`               |
 | `service.loadBalancerIP`           | IP address to assign to load balancer (if supported)                                                                                      | `""`                |
 | `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported)                                                                           | `[]`                |
 | `service.sslLdapPort`              | External service port for SSL+LDAP                                                                                                        | `636`               |
-| `service.sslLdapPortNodePort`                 | Nodeport of External service port for SSL if service.type is NodePort                                                                                                            | `nil`               |
-| `service.type`                     | Service type can be ClusterIP, NodePort, LoadBalancer                                                                                                                              | `ClusterIP`         |
+| `service.sslLdapPortNodePort`      | Nodeport of External service port for SSL if service.type is NodePort                                                                     | `nil`               |
+| `service.type`                     | Service type can be ClusterIP, NodePort, LoadBalancer                                                                                     | `ClusterIP`         |
 | `env`                              | List of key value pairs as env variables to be sent to the docker image. See https://github.com/osixia/docker-openldap for available ones | `[see values.yaml]` |
 | `logLevel`                         | Set the container log level. Valid values: `none`, `error`, `warning`, `info`, `debug`, `trace`                                           | `info`              |
-| `customTLS.enabled`                      | Set to enable TLS/LDAPS with custom certificate - should also set `tls.secret`                                                                                    | `false`             |
-| `customTLS.secret`                       | Secret containing TLS cert and key must contain the keys tls.key , tls.crt and ca.crt (if tls.CA.enabled: true)                                                                       | `""`                |
-| `customTLS.CA.enabled`                   | Set to enable custom CA crt file                                                                         | `false`             |
+| `customTLS.enabled`                | Set to enable TLS/LDAPS with custom certificate - should also set `tls.secret`                                                            | `false`             |
+| `customTLS.secret`                 | Secret containing TLS cert and key must contain the keys tls.key , tls.crt and ca.crt (if tls.CA.enabled: true)                           | `""`                |
+| `customTLS.CA.enabled`             | Set to enable custom CA crt file                                                                                                          | `false`             |
 | `adminPassword`                    | Password for admin user. Unset to auto-generate the password                                                                              | None                |
 | `configPassword`                   | Password for config user. Unset to auto-generate the password                                                                             | None                |
 | `customLdifFiles`                  | Custom ldif files to seed the LDAP server. List of filename -> data pairs                                                                 | None                |
 | `customFileSets`                   | Custom filesets to be mounted, see values.yaml for example.                                                                               | None                |
 | `persistence.enabled`              | Whether to use PersistentVolumes or not                                                                                                   | `false`             |
 | `persistence.storageClass`         | Storage class for PersistentVolumes.                                                                                                      | `<unset>`           |
-| `persistence.existingClaim`        | Add existing Volumes Claim. | `<unset>`           |
+| `persistence.existingClaim`        | Add existing Volumes Claim.                                                                                                               | `<unset>`           |
 | `persistence.accessMode`           | Access mode for PersistentVolumes                                                                                                         | `ReadWriteOnce`     |
 | `persistence.size`                 | PersistentVolumeClaim storage size                                                                                                        | `8Gi`               |
-| `extraVolumes`                     | Allow add extra volumes which could be mounted to statefulset | None |
-| `extraVolumeMounts`                | Add extra volumes to statefulset | None |
+| `extraVolumes`                     | Allow add extra volumes which could be mounted to statefulset                                                                             | None                |
+| `extraVolumeMounts`                | Add extra volumes to statefulset                                                                                                          | None                |
 | `livenessProbe`                    | Liveness probe configuration                                                                                                              | `[see values.yaml]` |
 | `readinessProbe`                   | Readiness probe configuration                                                                                                             | `[see values.yaml]` |
 | `startupProbe`                     | Startup probe configuration                                                                                                               | `[see values.yaml]` |
@@ -72,20 +75,20 @@ The following table lists the configurable parameters of the openldap chart and 
 | `test.enabled`                     | Conditionally provision test resources                                                                                                    | `false`             |
 | `test.image.repository`            | Test container image requires bats framework                                                                                              | `dduportal/bats`    |
 | `test.image.tag`                   | Test container tag                                                                                                                        | `0.4.0`             |
-| `replication.enabled`              | Enable the multi-master replication | `true` |
-| `replication.retry`              | retry period for replication in sec | `60` |
-| `replication.timeout`              | timeout for replication  in sec| `1` |
-| `replication.starttls`              | starttls replication | `critical` |
-| `replication.tls_reqcert`              | tls certificate validation for replication | `never` |
-| `replication.interval`              | interval for replication | `00:00:00:10` |
-| `replication.clusterName`          | Set the clustername for replication | "cluster.local" |
-| `phpldapadmin.enabled`             | Enable the deployment of PhpLdapAdmin | `true`|
-| `phpldapadmin.ingress`             | Ingress of Phpldapadmin | `{}` |
-| `phpldapadmin.env`  | Environment variables for PhpldapAdmin| `{}` |
-|`ltb-passwd.enabled`| Enable the deployment of Ltb-Passwd| `true` |
-|`ltb-passwd.ingress`| Ingress of the Ltb-Passwd service | `{}` |
-|`ltb-passwd.ldap`| Ldap configuration for the Ltb-Passwd service | `{}` |
-|`ltb-passwd.env`| Environment variables for ltp-passwd | `{}` |
+| `replication.enabled`              | Enable the multi-master replication                                                                                                       | `true`              |
+| `replication.retry`                | retry period for replication in sec                                                                                                       | `60`                |
+| `replication.timeout`              | timeout for replication in sec                                                                                                            | `1`                 |
+| `replication.starttls`             | starttls replication                                                                                                                      | `critical`          |
+| `replication.tls_reqcert`          | tls certificate validation for replication                                                                                                | `never`             |
+| `replication.interval`             | interval for replication                                                                                                                  | `00:00:00:10`       |
+| `replication.clusterName`          | Set the clustername for replication                                                                                                       | "cluster.local"     |
+| `phpldapadmin.enabled`             | Enable the deployment of PhpLdapAdmin                                                                                                     | `true`              |
+| `phpldapadmin.ingress`             | Ingress of Phpldapadmin                                                                                                                   | `{}`                |
+| `phpldapadmin.env`                 | Environment variables for PhpldapAdmin                                                                                                    | `{}`                |
+| `ltb-passwd.enabled`               | Enable the deployment of Ltb-Passwd                                                                                                       | `true`              |
+| `ltb-passwd.ingress`               | Ingress of the Ltb-Passwd service                                                                                                         | `{}`                |
+| `ltb-passwd.ldap`                  | Ldap configuration for the Ltb-Passwd service                                                                                             | `{}`                |
+| `ltb-passwd.env`                   | Environment variables for ltp-passwd                                                                                                      | `{}`                |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
@@ -97,16 +100,17 @@ $ helm install --name my-release -f values.yaml stable/openldap
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
-
 ## PhpLdapAdmin
-To enable PhpLdapAdmin set `phpldapadmin.enabled`  to `true`
+
+To enable PhpLdapAdmin set `phpldapadmin.enabled` to `true`
 
 Ingress can be configure if you want to expose the service.
 Setup the env part of the configuration to access the OpenLdap server
 
 **Note** : The ldap host should match the following `namespace.Appfullname`
 
-Example : 
+Example :
+
 ```
 phpldapadmin:
   enabled: true
@@ -119,10 +123,12 @@ phpldapadmin:
     - phpldapadmin.local
   env:
     PHPLDAPADMIN_LDAP_HOSTS: openldap.openldap
-     
+
 ```
+
 ## Self-service-password
-To enable Self-service-password set `ltb-passwd.enabled`  to `true`
+
+To enable Self-service-password set `ltb-passwd.enabled` to `true`
 
 Ingress can be configure if you want to expose the service.
 
@@ -132,7 +138,8 @@ Set `bindDN` accordingly to your ldap domain
 
 **Note** : The ldap server host should match the following `ldap://namespace.Appfullname`
 
-Example : 
+Example :
+
 ```
 ltb-passwd:
   enabled : true
@@ -145,7 +152,7 @@ ltb-passwd:
     searchBase: dc=example,dc=org
     bindDN: cn=admin,dc=example,dc=org
     bindPWKey: LDAP_ADMIN_PASSWORD
-  
+
 ```
 
 ## Cleanup orphaned Persistent Volumes

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.service.enabled }}
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -46,3 +48,4 @@ spec:
   selector:
     app: {{ template "openldap.fullname" . }}
     release: {{ .Release.Name }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -3,23 +3,24 @@
 # Declare variables to be passed into your templates.
 
 replicaCount: 3
-updateStrategy: {}
-  # When a StatefulSet's .spec.updateStrategy.type is set to OnDelete, 
+updateStrategy:
+  {}
+  # When a StatefulSet's .spec.updateStrategy.type is set to OnDelete,
   # the StatefulSet controller will not automatically update the Pods
   # in a StatefulSet. Users must manually delete Pods to cause the
   # controller to create new Pods that reflect modifications made
   # to a StatefulSet's .spec.template.
-  # 
+  #
   # type: OnDelete
-  # 
+  #
   # or
-  # 
+  #
   # When a StatefulSet's .spec.updateStrategy.type is set to RollingUpdate,
   # the StatefulSet controller will delete and recreate each Pod in the StatefulSet.
-  # It will proceed in the same order as Pod termination (from the largest ordinal 
+  # It will proceed in the same order as Pod termination (from the largest ordinal
   # to the smallest), updating each Pod one at a time. It will wait until an updated
   # Pod is Running and Ready prior to updating its predecessor.
-  # 
+  #
   # type: RollingUpdate
   # rollingUpdate:
   #   partition: 1
@@ -35,14 +36,14 @@ image:
 logLevel: info
 
 # Specifies an existing secret to be used for admin and config user passwords
-existingSecret: ""
+existingSecret: ''
 
 # Settings for enabling TLS with custom certificate
 # need a secret with tls.crt, tls.key and ca.crt keys with associated files
 # Ref: https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/#create-a-secret
 customTLS:
   enabled: false
-  secret: ""  # The name of a kubernetes.io/tls type secret to use for TLS
+  secret: '' # The name of a kubernetes.io/tls type secret to use for TLS
   CA:
     enabled: false
 ## Add additional labels to all resources
@@ -50,6 +51,7 @@ extraLabels: {}
 ## Add additional annotations to pods
 podAnnotations: {}
 service:
+  enabled: true
   annotations: {}
 
   ldapPort: 389
@@ -63,7 +65,7 @@ service:
   ##
   externalIPs: []
 
-  #loadBalancerIP: 
+  #loadBalancerIP:
   #loadBalancerSourceRanges: []
   type: ClusterIP
   sessionAffinity: None
@@ -83,30 +85,28 @@ extraVolumeMounts:
 # Default configuration for openldap as environment variables. These get injected directly in the container.
 # Use the env variables from https://github.com/osixia/docker-openldap#beginner-guide
 env:
- LDAP_LOG_LEVEL: "256"
- LDAP_ORGANISATION: "Example Inc."
- LDAP_DOMAIN: "example.org"
- LDAP_READONLY_USER: "false"
- LDAP_READONLY_USER_USERNAME: "readonly"
- LDAP_READONLY_USER_PASSWORD: "readonly"
- LDAP_RFC2307BIS_SCHEMA: "false"
- LDAP_BACKEND: "mdb"
- LDAP_TLS: "true"
- LDAP_TLS_CRT_FILENAME: "tls.crt"
- LDAP_TLS_KEY_FILENAME: "tls.key"
- LDAP_TLS_DH_PARAM_FILENAME: "dhparam.pem"
- LDAP_TLS_CA_CRT_FILENAME: "ca.crt"
- LDAP_TLS_ENFORCE: "false"
- CONTAINER_LOG_LEVEL: "4"
- LDAP_TLS_REQCERT: "never"
- KEEP_EXISTING_CONFIG: "false"
- LDAP_REMOVE_CONFIG_AFTER_SETUP: "true"
- LDAP_SSL_HELPER_PREFIX: "ldap"
- LDAP_TLS_VERIFY_CLIENT: "never"
- LDAP_TLS_PROTOCOL_MIN: "3.0"
- LDAP_TLS_CIPHER_SUITE: "NORMAL"
-
-  
+  LDAP_LOG_LEVEL: '256'
+  LDAP_ORGANISATION: 'Example Inc.'
+  LDAP_DOMAIN: 'example.org'
+  LDAP_READONLY_USER: 'false'
+  LDAP_READONLY_USER_USERNAME: 'readonly'
+  LDAP_READONLY_USER_PASSWORD: 'readonly'
+  LDAP_RFC2307BIS_SCHEMA: 'false'
+  LDAP_BACKEND: 'mdb'
+  LDAP_TLS: 'true'
+  LDAP_TLS_CRT_FILENAME: 'tls.crt'
+  LDAP_TLS_KEY_FILENAME: 'tls.key'
+  LDAP_TLS_DH_PARAM_FILENAME: 'dhparam.pem'
+  LDAP_TLS_CA_CRT_FILENAME: 'ca.crt'
+  LDAP_TLS_ENFORCE: 'false'
+  CONTAINER_LOG_LEVEL: '4'
+  LDAP_TLS_REQCERT: 'never'
+  KEEP_EXISTING_CONFIG: 'false'
+  LDAP_REMOVE_CONFIG_AFTER_SETUP: 'true'
+  LDAP_SSL_HELPER_PREFIX: 'ldap'
+  LDAP_TLS_VERIFY_CLIENT: 'never'
+  LDAP_TLS_PROTOCOL_MIN: '3.0'
+  LDAP_TLS_CIPHER_SUITE: 'NORMAL'
 
 # Default Passwords to use, stored as a secret.
 # You can override these at install time with
@@ -116,8 +116,8 @@ configPassword: Not@SecurePassw0rd
 
 # Custom openldap configuration files used to override default settings
 # customLdifFiles:
-  # 01-default-users.ldif: |-
-    # Predefine users here
+# 01-default-users.ldif: |-
+# Predefine users here
 
 # Custom files with provided contents to be added in container.
 customFileSets: []
@@ -132,14 +132,14 @@ customFileSets: []
 #      olcModuleLoad: memberof
 
 replication:
-  enabled: true    
+  enabled: true
   # Enter the name of your cluster, defaults to "cluster.local"
-  clusterName: "cluster.local"
+  clusterName: 'cluster.local'
   retry: 60
   timeout: 1
   interval: 00:00:00:10
-  starttls: "critical"
-  tls_reqcert: "never"
+  starttls: 'critical'
+  tls_reqcert: 'never'
 ## Persist data to a persistent volume
 persistence:
   enabled: true
@@ -180,18 +180,18 @@ startupProbe:
   successThreshold: 1
   failureThreshold: 30
 
-resources: {}
- # requests:
- #   cpu: "100m"
- #   memory: "256Mi"
- # limits:
- #   cpu: "500m"
- #   memory: "512Mi"
+resources:
+  {}
+  # requests:
+  #   cpu: "100m"
+  #   memory: "256Mi"
+  # limits:
+  #   cpu: "500m"
+  #   memory: "512Mi"
 
 nodeSelector: {}
 
 tolerations: []
-
 
 ## test container details
 test:
@@ -200,7 +200,7 @@ test:
     repository: dduportal/bats
     tag: 0.4.0
 ltb-passwd:
-  enabled : true
+  enabled: true
   ingress:
     enabled: true
     annotations: {}
@@ -208,7 +208,7 @@ ltb-passwd:
     pathType: Prefix
     ## Ingress Host
     hosts:
-    - "ssl-ldap2.example"
+      - 'ssl-ldap2.example'
   ldap:
     server: ldap://openldap-openldap-stack-ha
     searchBase: dc=example,dc=org
@@ -225,18 +225,17 @@ phpldapadmin:
     pathType: Prefix
     ## Ingress Host
     hosts:
-    - phpldapadmin.example
+      - phpldapadmin.example
   env:
     PHPLDAPADMIN_LDAP_HOSTS: openldap-openldap-stack-ha
- # TODO make it works
- #     "#PYTHON2BASH:
- #       [{'openldap.openldap': 
- #         [{'server': [
- #           {'tls': False},
- #           {'port':636}
- #         ]},
- #           {'login': 
- #             [{'bind_id': 'cn=admin,dc=example,dc=org'}]
- #           }]
- #       }]"
-     
+  # TODO make it works
+  #     "#PYTHON2BASH:
+  #       [{'openldap.openldap':
+  #         [{'server': [
+  #           {'tls': False},
+  #           {'port':636}
+  #         ]},
+  #           {'login':
+  #             [{'bind_id': 'cn=admin,dc=example,dc=org'}]
+  #           }]
+  #       }]"


### PR DESCRIPTION
### What this PR does / why we need it:
This is usual best practice to make the load-balancer service to be excluded from creation, so one can do it manually and use any custom service configuration needed.

For example also needed to fix #48 since - when i manually create a service with the external IP exposed.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you updated the readme?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss open a ticket first**