### PR TITLE
Add Pod Disruption Budget for Stateful Set

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ Parameters related to Kubernetes.
 | `podAnnotations`              | Enable the multi-master replication | `true` |
 | `podAffinityPreset`              | podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`| `` |
 | `podAntiAffinityPreset`              | podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `soft` |
+| `pdb.enabled`                      | Enable Pod Disruption Budget                                                                                                              | `false`             |
+| `pdb.minAvailable`                 | Configure PDB to have at least this many health replicas.                                                                                 | `1`                 |
+| `pdb.maxUnavailable`               | Configure PDB to have at most this many unhealth replicas.                                                                                | `<unset>`           |
 | `nodeAffinityPreset`              | nodeAffinityPreset.type Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `true` |
 | `affinity`              | affinity Affinity for OPENLDAP  pods assignment | `` |
 | `nodeSelector`              | nodeSelector Node labels for OPENLDAP  pods assignment | `` |

--- a/templates/pod-disruption-budget.yaml
+++ b/templates/pod-disruption-budget.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "openldap.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: {{ template "openldap.fullname" . }}
+    chart: {{ template "openldap.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels | indent 4 }}
+{{- end }}
+spec:
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  selector:
+    app.kubernetes.io/component: {{ template "openldap.fullname" . }}
+    release: {{ .Release.Name }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -115,6 +115,13 @@ env:
  LDAP_TLS_PROTOCOL_MIN: "3.0"
  LDAP_TLS_CIPHER_SUITE: "NORMAL"
 
+# Pod Disruption Budget for Stateful Set
+# Disabled by default, to ensure backwards compatibility
+pdb:
+  enabled: false
+  minAvailable: 1
+  maxUnavailable: ""
+
 # Custom openldap configuration files used to override default settings
 # customLdifFiles:
   # 01-default-users.ldif: |-


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. --> 
OpenLDAP clusters with multiple replicas should ask cluster operators to not shut all replicas at once (e.g. during Node Pool upgrades). A Pod Disruption Budget should be provided by the helm chart, for easy and consistent selector settings.

This change is backwards compatible with possible pre-existing PDBs and workflows allowing complete shutdown of clusters, as the flag to emit a PDB definition defaults to `false`.

Without this change, cluster owners are forced to create a PDB by themselves, manually managing the selector.

### Pre-submission checklist:

* [X] Did you explain what problem does this PR solve? Or what new features have been added?
* [X] Have you updated the readme?
* [X] Is this PR backward compatible? **If it is not backward compatible, please discuss open a ticket first**