### PR TITLE
Added port customization to liveness probe for the statefulset template

### DIFF
--- a/templates/statefullset.yaml
+++ b/templates/statefullset.yaml
@@ -140,9 +140,9 @@ spec:
           {{- end }}
           ports:
             - name: ldap-port
-              containerPort: 1389
+              containerPort: {{ .Values.ldapPort }}
             - name: ssl-ldap-port
-              containerPort: 1636
+              containerPort: {{ .Values.sslLdapPort }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             tcpSocket:


### PR DESCRIPTION
### What this PR does / why we need it:
Added port customization to liveness probe for the statefulset template
Without this using a custom port will fail if ports are not 1389 and 1636

### Pre-submission checklist:

* [X] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you updated the readme?
* [X] Is this PR backward compatible? **If it is not backward compatible, please discuss open a ticket first**