### PR TITLE
add customSchemaFiles option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,7 @@ There are some major changes between the Osixia version and the Bitnami version 
 
 - Upgrade may not work fine between `3.x` and `4.x`
 - Ldap and Ldaps port are non privileged ports (`1389` and `1636`) internally but are exposed through `global.ldapPort` and `global.sslLdapPort` (389 and 636)
-- Replication is now purely setup by configuration. Extra schemas are loaded using `LDAP_EXTRA_SCHEMAS: "cosine,inetorgperson,nis,syncprov,serverid,csyncprov,rep,bsyncprov,brep,acls".
-  - For now this list is harcoded and will be configurable in a future update.
-  - (let me know if you need this feature priorityzed)
+- Replication is now purely setup by configuration. Extra schemas are loaded using `LDAP_EXTRA_SCHEMAS: "cosine,inetorgperson,nis,syncprov,serverid,csyncprov,rep,bsyncprov,brep,acls`. You can add your own schemas via the `customSchemaFiles` option.
 
 A default tree (Root organisation, users and group) is created during startup, this can be skipped using `LDAP_SKIP_DEFAULT_TREE` , however you need to use `customLdifFiles` or `customLdifCm` to create a root organisation.
 
@@ -57,7 +55,7 @@ Global parameters to configure the deployment of the application.
 | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
 | `global.imageRegistry`                     | Global image registry                                                                                                                        | `""`                 |
 | `global.imagePullSecrets`                     | Global list of imagePullSecrets                                                                                                                        | `[]`                 |
-| `global.ldapDomain`                     | Domain LDAP can be explicit `dc=example,dc=org` or domain based `example.org`                                                                                                                         | `example.org`                 | 
+| `global.ldapDomain`                     | Domain LDAP can be explicit `dc=example,dc=org` or domain based `example.org`                                                                                                                         | `example.org`                 |
 | `global.existingSecret`                     | Use existing secret for credentials - the expected keys are LDAP_ADMIN_PASSWORD and LDAP_CONFIG_ADMIN_PASSWORD                                         | `""`                |
 | `global.adminPassword`                     | Administration password of Openldap                                                                                                                        | `Not@SecurePassw0rd`                 |
 | `global.configPassword`                     | Configuration password of Openldap                                                                                                                        | `Not@SecurePassw0rd`                 |
@@ -77,6 +75,7 @@ Parameters related to the configuration of the application.
 | `env`                              | List of key value pairs as env variables to be sent to the docker image. See https://github.com/bitnami/containers/tree/main/bitnami/openldap for available ones | `[see values.yaml]` |
 | `customTLS.enabled`                      | Set to enable TLS/LDAPS with custom certificate - should also set `tls.secret`                                                                                    | `false`             |
 | `customTLS.secret`                       | Secret containing TLS cert and key must contain the keys tls.key , tls.crt and ca.crt                                                                       | `""`                |
+| `customSchemaFiles` | Custom openldap schema files used in addition to default schemas                                                                    | `""`                |
 | `customLdifFiles`                       | Custom openldap configuration files used to override default settings                                                                      | `""`                |
 | `customLdifCm`                       | Existing configmap with custom ldif. Can't be use with customLdifFiles                                                            | `""`                |
 | `customAcls`                       | Custom openldap ACLs. Overrides default ones.                                                                      | `""`                |

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -181,17 +181,8 @@ Return the list of all schema files to use
 Cannot return list => return string comma separated
 */}}
 {{- define "openldap.schemaFiles" -}}
-  {{- /*  begin of shared part with "openldap.builtinSchemaFiles" */ -}}
-  {{- $schemas := "" -}}
-  {{- if .Values.replication.enabled -}}
-    {{- $schemas = "syncprov,serverid,csyncprov,rep,bsyncprov,brep,acls" -}}
-  {{- else -}}
-    {{- $schemas = "acls" -}}
-  {{- end -}}
-  {{- /* end of shared part with "openldap.builtinSchemaFiles" */ -}}
-  {{- /*  begin of shared part with "openldap.customSchemaFiles" */ -}}
-  {{- $custom_schemas := ((join "," (.Values.customSchemaFiles | keys))  | replace ".ldif" "") -}}
-  {{- /*  end of shared part with "openldap.customSchemaFiles" */ -}}
+  {{- $schemas := (include "openldap.builtinSchemaFiles" .) -}}
+  {{- $custom_schemas := (include "openldap.customSchemaFiles" .) -}}
   {{- if gt (len $custom_schemas) 0 -}}
     {{- $schemas = print $schemas "," $custom_schemas -}}
   {{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -176,29 +176,25 @@ Cannot return list => return string comma separated
   {{- print $schemas -}}
 {{- end -}}
 
-
 {{/*
 Return the list of all schema files to use
 Cannot return list => return string comma separated
 */}}
 {{- define "openldap.schemaFiles" -}}
-  # begin of shared part with "openldap.builtinSchemaFiles"
+  {{- /*  begin of shared part with "openldap.builtinSchemaFiles" */ -}}
   {{- $schemas := "" -}}
   {{- if .Values.replication.enabled -}}
     {{- $schemas = "syncprov,serverid,csyncprov,rep,bsyncprov,brep,acls" -}}
   {{- else -}}
     {{- $schemas = "acls" -}}
   {{- end -}}
-  # end of shared part with "openldap.builtinSchemaFiles"
-
-  # begin of shared part with "openldap.customSchemaFiles"
+  {{- /* end of shared part with "openldap.builtinSchemaFiles" */ -}}
+  {{- /*  begin of shared part with "openldap.customSchemaFiles" */ -}}
   {{- $custom_schemas := ((join "," (.Values.customSchemaFiles | keys))  | replace ".ldif" "") -}}
-  # end of shared part with "openldap.customSchemaFiles"
-
+  {{- /*  end of shared part with "openldap.customSchemaFiles" */ -}}
   {{- if gt (len $custom_schemas) 0 -}}
     {{- $schemas = print $schemas "," $custom_schemas -}}
   {{- end -}}
-
   {{- print $schemas -}}
 {{- end -}}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -151,16 +151,55 @@ Return the proper Openldap init container image name
 {{- include "common.images.image" (dict "imageRoot" .Values.customTLS.image "global" .Values.global) -}}
 {{- end -}}
 
+
 {{/*
-Return the list of schemas files to mount
+Return the list of builtin schema files to mount
+Cannot return list => return string comma separated
+*/}}
+{{- define "openldap.builtinSchemaFiles" -}}
+  {{- $schemas := "" -}}
+  {{- if .Values.replication.enabled -}}
+    {{- $schemas = "syncprov,serverid,csyncprov,rep,bsyncprov,brep,acls" -}}
+  {{- else -}}
+    {{- $schemas = "acls" -}}
+  {{- end -}}
+  {{- print $schemas -}}
+{{- end -}}
+
+{{/*
+Return the list of custom schema files to use
+Cannot return list => return string comma separated
+*/}}
+{{- define "openldap.customSchemaFiles" -}}
+  {{- $schemas := "" -}}
+  {{- $schemas := ((join "," (.Values.customSchemaFiles | keys))  | replace ".ldif" "") -}}
+  {{- print $schemas -}}
+{{- end -}}
+
+
+{{/*
+Return the list of all schema files to use
 Cannot return list => return string comma separated
 */}}
 {{- define "openldap.schemaFiles" -}}
-  {{- if .Values.replication.enabled }}
-    {{- print "syncprov,serverid,csyncprov,rep,bsyncprov,brep,acls" }}
+  # begin of shared part with "openldap.builtinSchemaFiles"
+  {{- $schemas := "" -}}
+  {{- if .Values.replication.enabled -}}
+    {{- $schemas = "syncprov,serverid,csyncprov,rep,bsyncprov,brep,acls" -}}
   {{- else -}}
-    {{- print "acls" }}
+    {{- $schemas = "acls" -}}
   {{- end -}}
+  # end of shared part with "openldap.builtinSchemaFiles"
+
+  # begin of shared part with "openldap.customSchemaFiles"
+  {{- $custom_schemas := ((join "," (.Values.customSchemaFiles | keys))  | replace ".ldif" "") -}}
+  # end of shared part with "openldap.customSchemaFiles"
+
+  {{- if gt (len $custom_schemas) 0 -}}
+    {{- $schemas = print $schemas "," $custom_schemas -}}
+  {{- end -}}
+
+  {{- print $schemas -}}
 {{- end -}}
 
 {{/*

--- a/templates/configmap-customschema.yaml
+++ b/templates/configmap-customschema.yaml
@@ -1,0 +1,23 @@
+#
+# A ConfigMap spec for openldap slapd that map directly to files under
+# /opt/bitnami/openldap/etc/schema/custom
+#
+{{- if .Values.customSchemaFiles }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "openldap.fullname" . }}-customschema
+  labels:
+    app: {{ template "openldap.name" . }}
+    chart: {{ template "openldap.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels | indent 4 }}
+{{- end }}
+data:
+{{- range $key, $val := .Values.customSchemaFiles }}
+  {{ $key }}: |-
+{{ $val | indent 4}}
+{{- end }}
+{{- end }}

--- a/templates/configmap-env.yaml
+++ b/templates/configmap-env.yaml
@@ -18,7 +18,7 @@ metadata:
 {{- end }}
 data:
   LDAP_ROOT: {{ include "global.baseDomain" . }}
-  LDAP_EXTRA_SCHEMAS: {{ cat "cosine,inetorgperson,nis," (include "openldap.schemaFiles" .) }}
+  LDAP_EXTRA_SCHEMAS: {{ print "cosine,inetorgperson,nis," (include "openldap.schemaFiles" .) }}
   {{- if .Values.users }}
   LDAP_USERS: {{ .Values.users }}
   {{- end }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -206,13 +206,13 @@ spec:
               mountPath: /opt/bitnami/openldap/certs
             {{- range $file := (include "openldap.builtinSchemaFiles" . | split ",") }}
             - name: replication-acls
-              mountPath: /opt/bitnami/openldap/etc/schema/{{ $file }}
+              mountPath: /opt/bitnami/openldap/etc/schema/{{ $file }}.ldif
               subPath: {{ $file }}.ldif
             {{- end }}
 {{- if .Values.customSchemaFiles}}
             {{- range $file := (include "openldap.customSchemaFiles" . | split ",") }}
             - name: custom-schema-files
-              mountPath: /opt/bitnami/openldap/etc/schema/{{ $file }}
+              mountPath: /opt/bitnami/openldap/etc/schema/{{ $file }}.ldif
               subPath: {{ $file }}.ldif
             {{- end }}
 {{- end }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -204,11 +204,18 @@ spec:
               mountPath: /bitnami/openldap/
             - name: certs
               mountPath: /opt/bitnami/openldap/certs
-            {{- range $file := (include "openldap.schemaFiles" . | split ",") }}
+            {{- range $file := (include "openldap.builtinSchemaFiles" . | split ",") }}
             - name: replication-acls
-              mountPath: /opt/bitnami/openldap/etc/schema/{{ $file }}.ldif
+              mountPath: /opt/bitnami/openldap/etc/schema/{{ $file }}
               subPath: {{ $file }}.ldif
             {{- end }}
+{{- if .Values.customSchemaFiles}}
+            {{- range $file := (include "openldap.customSchemaFiles" . | split ",") }}
+            - name: custom-schema-files
+              mountPath: /opt/bitnami/openldap/etc/schema/{{ $file }}
+              subPath: {{ $file }}.ldif
+            {{- end }}
+{{- end }}
 {{- if or (.Values.customLdifFiles) (.Values.customLdifCm) }}
             - name: custom-ldif-files
               mountPath: /ldifs/
@@ -255,6 +262,11 @@ spec:
         - name: custom-ldif-files
           configMap:
             name: {{ .Values.customLdifCm }}
+{{- end }}
+{{- if .Values.customSchemaFiles }}
+        - name: custom-schema-files
+          configMap:
+            name: {{ template "openldap.fullname" . }}-customschema
 {{- end }}
         - name: certs
           emptyDir:

--- a/values.yaml
+++ b/values.yaml
@@ -119,10 +119,17 @@ pdb:
 ## Default set by bitnami image
 # group: readers
 
+# Custom openldap schema files used to be used in addition to default schemas
+# customSchemaFiles:
+#   custom.ldif: |-
+#     # custom schema
+#   anothercustom.ldif: |-
+#     # another custom schema
+
 ## Existing configmap with custom ldif
 # Can't be use with customLdifFiles
 # Same format as customLdifFiles
-# customLdifCm: my-custom-cm
+# customLdifCm: my-custom-ldif-cm
 
 # Custom openldap configuration files used to override default settings
 # DO NOT FORGET to put the Root Organisation object as it won't be created while using customLdifFiles


### PR DESCRIPTION
### What this PR does / why we need it:

Solves following feature request from the Readme:

```
- Replication is now purely setup by configuration. Extra schemas are loaded using `LDAP_EXTRA_SCHEMAS: "cosine,inetorgperson,nis,syncprov,serverid,csyncprov,rep,bsyncprov,brep,acls".
  - For now this list is harcoded and will be configurable in a future update.
  - (let me know if you need this feature priorityzed)
```

It now allows you to set custom schemas in `customSchemaFiles` like you can do with `customLdifFiles` for LDIF files.
Sadly I found no way to support a `customSchemaCm` analogous to `customLdifCm` (because of the subPath mount logic in statefulset.yaml).

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you updated the readme?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss open a ticket first**
