### PR TITLE
Fix: invalid configmap key when using custom schema files

### DIFF
--- a/templates/configmap-customschema.yaml
+++ b/templates/configmap-customschema.yaml
@@ -17,7 +17,7 @@ metadata:
 {{- end }}
 data:
 {{- range $key, $val := .Values.customSchemaFiles }}
-  {{ $key }}: |-
+  {{ $key }}.ldif: |-
 {{ $val | indent 4}}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When using customSchemaFiles (e.g. `ppolicy`), the key in configmap is `ppolicy`, however, in the deployment it loads subpath of configmap map as `ppolicy.ldif`

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you updated the readme?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss open a ticket first**