### PR TITLE
Fix: Add extra pod annotation to the statefulset template

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Parameters related to Kubernetes.
 | `containerSecurityContext`              | Set OPENLDAP  pod's Security Context fsGroup | `true` |
 | `existingConfigmap`              | existingConfigmap The name of an existing ConfigMap with your custom configuration for OPENLDAP  | `` |
 | `podLabels`              | podLabels Extra labels for OPENLDAP  pods| `{}` |
-| `podAnnotations`              | Enable the multi-master replication | `true` |
+| `podAnnotations`              | podAnnotations Annotations for OPENLDAP  pods | `{}` |
 | `podAffinityPreset`              | podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`| `` |
 | `podAntiAffinityPreset`              | podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `soft` |
 | `pdb.enabled`                      | Enable Pod Disruption Budget                                                                                                              | `false`             |

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Parameters related to Kubernetes.
 | `containerSecurityContext`              | Set OPENLDAP  pod's Security Context fsGroup | `true` |
 | `existingConfigmap`              | existingConfigmap The name of an existing ConfigMap with your custom configuration for OPENLDAP  | `` |
 | `podLabels`              | podLabels Extra labels for OPENLDAP  pods| `{}` |
-| `podAnnotations`              | podAnnotations Annotations for OPENLDAP  pods | `{}` |
+| `podAnnotations`              | podAnnotations Extra annotations for OPENLDAP  pods | `{}` |
 | `podAffinityPreset`              | podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`| `` |
 | `podAntiAffinityPreset`              | podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `soft` |
 | `pdb.enabled`                      | Enable Pod Disruption Budget                                                                                                              | `false`             |

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -26,6 +26,9 @@ spec:
   template:
     metadata:
       annotations:
+        {{- if .Values.podAnnotations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
         checksum/configmap-env: {{ include (print $.Template.BasePath "/configmap-env.yaml") . | sha256sum }}
         {{- if .Values.customLdifFiles}}
         checksum/configmap-customldif: {{ include (print $.Template.BasePath "/configmap-customldif.yaml") . | sha256sum }}


### PR DESCRIPTION
### What this PR does / why we need it:
"podAnnotations" parameter is defined in values.yaml file but not used in the actual statefulset/pod template. Therefore it is impossible to add additional pod annotation to the openldap pods currently. This PR fixes the issue.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you updated the readme?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss open a ticket first**