### PR TITLE
Copy tls.crt to ca.crt always unless ca.crt exists

### DIFF
--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -53,10 +53,10 @@ spec:
             - |
               {{- if not .Values.customTLS.enabled}}
               openssl req -x509 -newkey rsa:4096 -nodes -subj '/CN={{ .Values.global.ldapDomain }}' -keyout /tmp-certs/tls.key -out /tmp-certs/tls.crt -days 365
-              cp /tmp-certs/tls.crt /tmp-certs/ca.crt
               chmod 777  /tmp-certs/*
               {{- end }}
               cp -Lr /tmp-certs/* /certs
+              [ -e /certs/ca.crt ] || cp -a /certs/{tls,ca}.crt
           volumeMounts:
             - name: certs
               mountPath: "/certs"

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -56,7 +56,7 @@ spec:
               chmod 777  /tmp-certs/*
               {{- end }}
               cp -Lr /tmp-certs/* /certs
-              [ -e /certs/ca.crt ] || cp -a /certs/{tls,ca}.crt
+              [ -e /certs/ca.crt ] || cp -a /certs/tls.crt /certs/ca.crt
           volumeMounts:
             - name: certs
               mountPath: "/certs"


### PR DESCRIPTION
Previously the init container only copied tls.crt to ca.crt after generating a new certificate. When using cert-manager with an ACME issuer to generate a certificate, the resulting secret will also not have a ca.crt. When doing the copy like this, both cases would be covered without impacting other cases.