### PR TITLE
Allow overriding global.server value

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Global parameters to configure the deployment of the application.
 | `global.configPassword`                     | Configuration password of Openldap                                                                                                                        | `Not@SecurePassw0rd`                 |
 | `global.ldapPort`                     | Ldap port                                                                                                                         | `389`                 |
 | `global.sslLdapPort`                     | Ldaps port                                                                                                                         | `636`                 |
+| `global.serverOverride`                  | Override global.server used by phpldapadmin and ltb                                                                                | `""`                  |
 
 ### Application parameters
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -218,7 +218,11 @@ dc={{ $part }},
 Return the server name
 */}}
 {{- define "global.server" -}}
+{{- if .Values.global.serverOverride -}}
+{{- .Values.global.serverOverride -}}
+{{- else -}}
 {{- printf "%s.%s" .Release.Name .Release.Namespace  -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/values.yaml
+++ b/values.yaml
@@ -24,6 +24,8 @@ global:
   configPassword: Not@SecurePassw0rd
   ldapPort: 389
   sslLdapPort: 636
+  ## Override global.server used by phpldapadmin and ltb
+  # serverOverride: ""
 
 ## @section Common parameters
 


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I am using this helm chart with a custom nameOverride, which results in the service name not matching .Release.Name.
Thus, phpldapadmin is not able to connect to openldap.
It would be nice to be able to override the value of global.server which is currently used by phpldapadmin and ltb.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you updated the readme?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss open a ticket first**