### PR TITLE
fix: Allow IPv6 on ltb-passwd

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -480,6 +480,18 @@ ltb-passwd:
     # bindDN: "cn=....,dc=mydomain,dc=com"
     # if you want to use a specific key of the credentials secret instead of the default one (LDAP_ADMIN_PASSWORD)
     # passKey: LDAP_MY_KEY
+  env:
+  - name: SECRETKEY
+    value: "password"
+  - name: LDAP_LOGIN_ATTRIBUTE
+    value: "cn"
+  - name: LDAP_STARTTLS
+    value: "false"
+  - name: CHANGE_SSHKEY
+    value: "true"
+  - name: NGINX_LISTEN_PORT
+    value: "[::]:80 ipv6only=off"
+
 
 ## phpldapadmin
 ## For more parameters check following file: ./charts/phpldapadmin/values.yaml


### PR DESCRIPTION
### What this PR does / why we need it:
* Listen on both IPv4 and IPv6 in the ltb-passwd to fix health probes on dual-stack clusters.
* Include upstream chart env in main values.yaml.

https://github.com/tiredofit/docker-self-service-password/issues/66

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you updated the readme?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss open a ticket first**