### PR TITLE
Fixing customSchemaFiles

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -169,14 +169,6 @@ Cannot return list => return string comma separated
 {{- end -}}
 
 {{/*
-Return the list of custom schema files to use
-Cannot return list => return string comma separated
-*/}}
-{{- define "openldap.customSchemaFiles" -}}
-  {{- $schemas := "" -}}
-  {{- $schemas := ((join "," (.Values.customSchemaFiles | keys))  | replace ".ldif" "") -}}
-  {{- print $schemas -}}
-{{- end -}}
 
 {{/*
 Return the list of all schema files to use
@@ -184,10 +176,6 @@ Cannot return list => return string comma separated
 */}}
 {{- define "openldap.schemaFiles" -}}
   {{- $schemas := (include "openldap.builtinSchemaFiles" .) -}}
-  {{- $custom_schemas := (include "openldap.customSchemaFiles" .) -}}
-  {{- if gt (len $custom_schemas) 0 -}}
-    {{- $schemas = print $schemas "," $custom_schemas -}}
-  {{- end -}}
   {{- print $schemas -}}
 {{- end -}}
 

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -33,6 +33,9 @@ spec:
         {{- if .Values.customLdifFiles}}
         checksum/configmap-customldif: {{ include (print $.Template.BasePath "/configmap-customldif.yaml") . | sha256sum }}
         {{- end }}
+        {{- if .Values.customSchemaFiles}}
+        checksum/configmap-customschema: {{ include (print $.Template.BasePath "/configmap-customschema.yaml") . | sha256sum }}
+        {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: {{ template "openldap.fullname" . }}
         release: {{ .Release.Name }}
@@ -213,11 +216,8 @@ spec:
               subPath: {{ $file }}.ldif
             {{- end }}
 {{- if .Values.customSchemaFiles}}
-            {{- range $file := (include "openldap.customSchemaFiles" . | split ",") }}
             - name: custom-schema-files
-              mountPath: /opt/bitnami/openldap/etc/schema/{{ $file }}.ldif
-              subPath: {{ $file }}.ldif
-            {{- end }}
+              mountPath: /schemas/
 {{- end }}
 {{- if or (.Values.customLdifFiles) (.Values.customLdifCm) }}
             - name: custom-ldif-files


### PR DESCRIPTION
### What this PR does / why we need it:
customSchemaFiles were not being placed in the /schemas directory as the bitnami env var LDAP_CUSTOM_SCHEMA_DIR defaults to.  This is nearly identical to the behavior of LDAP_CUSTOM_LDIF_DIR so I altered customSchemaFiles to be similar to customLdifFiles.
