### PR TITLE
Allow to disable port on services.

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
       - bitnami-common
     version: 1.x.x
 home: https://www.openldap.org
-version: 4.2.2
+version: 4.2.3
 appVersion: 2.6.6
 description: Community developed LDAP software
 icon: https://raw.githubusercontent.com/jp-gouin/helm-openldap/master/logo.png

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Parameters related to Kubernetes.
 | `extraDeploy`                   | extraDeploy Array of extra objects to deploy with the release                                                                                | `""`                |
 | `service.annotations`              | Annotations to add to the service                                                                                                         | `{}`                |
 | `service.externalIPs`              | Service external IP addresses                                                                                                             | `[]`                |
+| `service.enableLdapPort`                 | Enable LDAP port on the service and headless service                                                                                | `true`              |
+| `service.enableSslLdapPort`                 | Enable SSL LDAP port on the service and headless service                                                                         | `true`              |
 | `service.ldapPortNodePort`                 | Nodeport of External service port for LDAP if service.type is NodePort                                                                                                            | `nil`               |
 | `service.loadBalancerIP`           | IP address to assign to load balancer (if supported)                                                                                      | `""`                |
 | `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported)                                                                           | `[]`                |

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -24,6 +24,7 @@ spec:
   loadBalancerSourceRanges: {{ toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
   ports:
+    {{- if .Values.service.enableLdapPort }}
     - name: ldap-port
       protocol: TCP
       port: {{ .Values.global.ldapPort }}
@@ -33,6 +34,8 @@ spec:
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    {{- end }}
+    {{- if .Values.service.enableSslLdapPort }}
     - name: ssl-ldap-port
       protocol: TCP
       port: {{ .Values.global.sslLdapPort }}
@@ -42,6 +45,7 @@ spec:
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    {{- end }}
   sessionAffinity: {{ .Values.service.sessionAffinity }}
   selector:
     app.kubernetes.io/component: {{ template "openldap.fullname" . }}

--- a/templates/svc-headless.yaml
+++ b/templates/svc-headless.yaml
@@ -9,9 +9,16 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   ports:
+  {{- if .Values.service.enableLdapPort }}
   - port: {{ .Values.global.ldapPort }}
     name: ldap-port
     targetPort: ldap-port
+  {{- end }}
+  {{- if .Values.service.enableSslLdapPort }}
+  - port: {{ .Values.global.sslLdapPort }}
+    name: ssl-ldap-port
+    targetPort: ssl-ldap-port
+  {{- end }}
   clusterIP: None
   selector:
     app.kubernetes.io/component: {{ template "openldap.fullname" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -79,6 +79,11 @@ service:
   ## If service type NodePort, define the value here
   #ldapPortNodePort:
   #sslLdapPortNodePort:
+
+  # Disable if you do not want to expose port on service
+  enableLdapPort: true
+  enableSslLdapPort: true
+
   ## List of IP addresses at which the service is available
   ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
   ##


### PR DESCRIPTION
### What this PR does / why we need it:
When using service as load balancer, if we setup ldap to be on secure port only we don't want to expose the insecure port. Currently there is no way to do that.

With this modification, users can enable or disable exposition of insecure or secure port on the service.

Default values keep the current behaviour.

### Pre-submission checklist:

* [X] Did you explain what problem does this PR solve? Or what new features have been added?
* [X] Have you updated the readme?
* [X] Is this PR backward compatible? This is backward compatible