### PR TITLE
Allow to disable port on services.

### DIFF
--- a/.bin/disableLdapPort.yaml
+++ b/.bin/disableLdapPort.yaml
@@ -1,0 +1,25 @@
+logLevel: debug
+resources:
+  limits:
+    cpu: "128m"
+    memory: "64Mi"
+replicaCount: 3
+customLdifFiles:
+  00-root.ldif: |-
+    # Root creation
+    dn: dc=example,dc=org
+    objectClass: dcObject
+    objectClass: organization
+    o: Example, Inc
+service:
+  enableLdapPort: false
+  sslLdapPortNodePort: 30636
+  type: NodePort
+initTLSSecret:
+  tls_enabled: true
+  image:
+    registry: docker.io
+    repository: alpine/openssl
+    tag: latest
+    pullPolicy: IfNotPresent
+  secret: "custom-cert"

--- a/.bin/simpleUser.ldif
+++ b/.bin/simpleUser.ldif
@@ -1,0 +1,12 @@
+dn: cn=Jean Dupond,dc=example,dc=org
+cn: Jean Dupond
+gidnumber: 500
+givenname: Jean
+homedirectory: /home/users/jdupond
+objectclass: inetOrgPerson
+objectclass: posixAccount
+objectclass: top
+sn: Dupond
+uid: jdupond
+uidnumber: 1000
+userpassword: {MD5}KOULhzfBhPTq9k7a9XfCGw==

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,24 @@ jobs:
            LDAPTLS_REQCERT=never ldapsearch -x -D 'cn=admin,dc=singlenode,dc=org' -w Not@SecurePassw0rd -H ldaps://localhost:30636 -b 'dc=singlenode,dc=org' > /tmp/test-single-node.txt
            cat /tmp/test-single-node.txt
            if [ $(grep "numResponses" /tmp/test-single-node.txt | cut -d ":" -f 2 | tr -d ' ') -ne 6 ]; then exit 1 ; fi
+      - name: deploy openldap-stack-ha-disable-ldap-port
+        shell: bash
+        run: |
+          helm delete openldap-stack-ha
+          cd "$GITHUB_WORKSPACE"
+          kubectl -n no-ldap-port create secret generic custom-cert --from-file=./tls.crt --from-file=./tls.key --from-file=./ca.crt
+          helm install openldap-stack-ha -n no-ldap-port --create-namespace -f .bin/disbaleLdpaPort.yaml .
+          kubectl -n no-ldap-port rollout status sts openldap-stack-ha -n no-ldap-port
+      - name: verify no ldap port deployment
+        shell: bash
+        run: |
+           echo "test access to openldap database"
+           sudo apt-get install -y ldap-utils
+           echo "Write test to openldap database"
+           LDAPTLS_REQCERT=never ldapadd -x -D 'cn=admin,dc=example,dc=org' -w Not@SecurePassw0rd -H ldaps://localhost:30636 -f .bin/simpleUser.ldif
+           LDAPTLS_REQCERT=never ldapsearch -o nettimeout=20 -x -D 'cn=admin,dc=example,dc=org' -w Not@SecurePassw0rd -H ldaps://localhost:30636 -b 'dc=example,dc=org' > /tmp/test-write.txt
+           cat /tmp/test-write.txt
+           if [ $(grep "numResponses" /tmp/test-write.txt | cut -d ":" -f 2 | tr -d ' ') -ne 3 ]; then exit 1 ; fi
 
 
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
       - name: deploy openldap-stack-ha-disable-ldap-port
         shell: bash
         run: |
-          helm delete openldap-stack-ha
+          helm delete -n single openldap-stack-ha
           cd "$GITHUB_WORKSPACE"
           kubectl -n no-ldap-port create secret generic custom-cert --from-file=./tls.crt --from-file=./tls.key --from-file=./ca.crt
           helm install openldap-stack-ha -n no-ldap-port --create-namespace -f .bin/disbaleLdpaPort.yaml .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           helm delete -n single openldap-stack-ha
           cd "$GITHUB_WORKSPACE"
-          helm install openldap-stack-ha -n no-ldap-port --create-namespace -f .bin/disbaleLdpaPort.yaml .
+          helm install openldap-stack-ha -n no-ldap-port --create-namespace -f .bin/disableLdapPort.yaml .
           kubectl -n no-ldap-port create secret generic custom-cert --from-file=./tls.crt --from-file=./tls.key --from-file=./ca.crt
           kubectl -n no-ldap-port rollout status sts openldap-stack-ha -n no-ldap-port
       - name: verify no ldap port deployment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,8 +110,8 @@ jobs:
         run: |
           helm delete -n single openldap-stack-ha
           cd "$GITHUB_WORKSPACE"
-          kubectl -n no-ldap-port create secret generic custom-cert --from-file=./tls.crt --from-file=./tls.key --from-file=./ca.crt
           helm install openldap-stack-ha -n no-ldap-port --create-namespace -f .bin/disbaleLdpaPort.yaml .
+          kubectl -n no-ldap-port create secret generic custom-cert --from-file=./tls.crt --from-file=./tls.key --from-file=./ca.crt
           kubectl -n no-ldap-port rollout status sts openldap-stack-ha -n no-ldap-port
       - name: verify no ldap port deployment
         shell: bash

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
       - bitnami-common
     version: ~2
 home: https://www.openldap.org
-version: 4.2.2
+version: 4.2.3
 appVersion: 2.6.6
 description: Community developed LDAP software
 icon: https://raw.githubusercontent.com/jp-gouin/helm-openldap/master/logo.png

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Parameters related to Kubernetes.
 | `extraDeploy`                   | extraDeploy Array of extra objects to deploy with the release                                                                                | `""`                |
 | `service.annotations`              | Annotations to add to the service                                                                                                         | `{}`                |
 | `service.externalIPs`              | Service external IP addresses                                                                                                             | `[]`                |
+| `service.enableLdapPort`                 | Enable LDAP port on the service and headless service                                                                                | `true`              |
+| `service.enableSslLdapPort`                 | Enable SSL LDAP port on the service and headless service                                                                         | `true`              |
 | `service.ldapPortNodePort`                 | Nodeport of External service port for LDAP if service.type is NodePort                                                                                                            | `nil`               |
 | `service.loadBalancerIP`           | IP address to assign to load balancer (if supported)                                                                                      | `""`                |
 | `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported)                                                                           | `[]`                |

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -24,6 +24,7 @@ spec:
   loadBalancerSourceRanges: {{ toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
   ports:
+    {{- if .Values.service.enableLdapPort }}
     - name: ldap-port
       protocol: TCP
       port: {{ .Values.global.ldapPort }}
@@ -33,6 +34,8 @@ spec:
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    {{- end }}
+    {{- if .Values.service.enableSslLdapPort }}
     - name: ssl-ldap-port
       protocol: TCP
       port: {{ .Values.global.sslLdapPort }}
@@ -42,6 +45,7 @@ spec:
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    {{- end }}
   sessionAffinity: {{ .Values.service.sessionAffinity }}
   selector:
     app.kubernetes.io/component: {{ template "openldap.fullname" . }}

--- a/templates/svc-headless.yaml
+++ b/templates/svc-headless.yaml
@@ -9,9 +9,16 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   ports:
+  {{- if .Values.service.enableLdapPort }}
   - port: {{ .Values.global.ldapPort }}
     name: ldap-port
     targetPort: ldap-port
+  {{- end }}
+  {{- if .Values.service.enableSslLdapPort }}
+  - port: {{ .Values.global.sslLdapPort }}
+    name: ssl-ldap-port
+    targetPort: ssl-ldap-port
+  {{- end }}
   clusterIP: None
   selector:
     app.kubernetes.io/component: {{ template "openldap.fullname" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -79,6 +79,11 @@ service:
   ## If service type NodePort, define the value here
   #ldapPortNodePort:
   #sslLdapPortNodePort:
+
+  # Disable if you do not want to expose port on service
+  enableLdapPort: true
+  enableSslLdapPort: true
+
   ## List of IP addresses at which the service is available
   ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
   ##


### PR DESCRIPTION
### What this PR does / why we need it:

When using service as load balancer, if we setup ldap to be on secure port only we don't want to expose the insecure port. Currently there is no way to do that.

With this modification, users can enable or disable exposition of insecure or secure port on the service.

Default values keep the current behaviour.

### Pre-submission checklist:

* [X] Did you explain what problem does this PR solve? Or what new features have been added?
* [X] Have you updated the readme?
* [X] Is this PR backward compatible? **If it is not backward compatible, please discuss open a ticket first**