### PR TITLE
feat(helpers): sort schema apply sequence

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -188,7 +188,7 @@ Cannot return list => return string comma separated
 */}}
 {{- define "openldap.customSchemaFiles" -}}
   {{- $schemas := "" -}}
-  {{- $schemas := ((join "," (.Values.customSchemaFiles | keys))  | replace ".ldif" "") -}}
+  {{- $schemas := ((join "," (.Values.customSchemaFiles | keys | sortAlpha))  | replace ".ldif" "") -}}
   {{- print $schemas -}}
 {{- end -}}
 

--- a/values.yaml
+++ b/values.yaml
@@ -121,6 +121,8 @@ pdb:
 # group: readers
 
 # Custom openldap schema files used to be used in addition to default schemas
+# Note that the supplied files are sorted by name and inserted into 'LDAP_EXTRA_SCHEMAS' env var
+# after chart default schemas, allowing you to control the loading sequence.
 # customSchemaFiles:
 #   custom.ldif: |-
 #     # custom schema


### PR DESCRIPTION
### What this PR does / why we need it:
Custom schema filenames are inserted into LDAP_EXTRA_SCHEMAS in an unsorted fashion, causing inconsistencies every time a new schema is added, or even in a different version of the helm. This commit enable customSchemaFiles keys sorting, allowing control over the loading sequence and using dependent custom schemas.

### Pre-submission checklist:
* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you updated the readme? (noted in values.yaml)
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss open a ticket first**