### PR TITLE
add support for short domain 'o=toto'

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
       - bitnami-common
     version: ~2
 home: https://www.openldap.org
-version: 4.2.4
+version: 4.2.5
 appVersion: 2.6.7
 description: Community developed LDAP software
 icon: https://raw.githubusercontent.com/jp-gouin/helm-openldap/master/logo.png

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -217,7 +217,7 @@ Return the proper base domain
 tmp method to iterate through the ldapDomain
 */}}
 {{- define "tmp.baseDomain" -}}
-{{- if regexMatch ".*=.*,.*" .Values.global.ldapDomain }}
+{{- if regexMatch ".*=.*" .Values.global.ldapDomain }}
 {{- printf "%s" .Values.global.ldapDomain }}
 {{- else }}
 {{- $parts := split "." .Values.global.ldapDomain }}


### PR DESCRIPTION
### What this PR does / why we need it:
Allow user to use short domain name for the `LDAP_ROOT` e.g : `o=domain` or `example` which will be  translated to `dc=example` 

### Pre-submission checklist:

* [X] Did you explain what problem does this PR solve? Or what new features have been added?
* [X] Is this PR backward compatible? **If it is not backward compatible, please discuss open a ticket first**