### PR TITLE
support customSchemaFiles and extraSchemaFiles options

### DIFF
--- a/.bin/myval.yaml
+++ b/.bin/myval.yaml
@@ -1,5 +1,5 @@
 logLevel: debug
-resources: 
+resources:
   limits:
     cpu: "128m"
     memory: "64Mi"
@@ -7,13 +7,13 @@ replicaCount: 3
 ltb-passwd:
   ingress:
     hosts:
-    - "ssl-ldap2.example"
+      - "ssl-ldap2.example"
 phpldapadmin:
   ingress:
     hosts:
-    - "phpldapadmin.example"
-customSchemaFiles:
-  00-memberof.ldif: |-
+      - "phpldapadmin.example"
+extraSchemaFiles:
+  memberof.ldif: |-
     # Load memberof module
     dn: cn=module,cn=config
     cn: module
@@ -27,8 +27,8 @@ customSchemaFiles:
     objectClass: olcMemberOf
     olcOverlay: memberof
     olcMemberOfRefint: TRUE
-    
-  10_owncloud_schema.ldif: |-
+customSchemaFiles:
+  00_owncloud_schema.ldif: |-
     # This LDIF files describes the ownCloud schema and can be used to
     # add two optional attributes: ownCloudQuota and ownCloudUUID
     # The ownCloudUUID is used to store a unique, non-reassignable, persistent identifier for users and groups
@@ -105,4 +105,4 @@ initTLSSecret:
     repository: alpine/openssl
     tag: latest
     pullPolicy: IfNotPresent
-  secret: "custom-cert" 
+  secret: "custom-cert"

--- a/README.md
+++ b/README.md
@@ -4,37 +4,40 @@
 ![Version](https://img.shields.io/static/v1?label=Openldap&message=2.6.3&color=blue)
 
 # OpenLDAP Helm Chart
+
 ## Disclaimer
+
 This version now use the [Bitnami Openldap](https://hub.docker.com/r/bitnami/openldap) container image.
 
 More detail on the container image can be found [here](https://github.com/bitnami/containers/tree/main/bitnami/openldap)
 
-The chart now support `Bitnami/Openldap 2.6.6`. 
+The chart now support `Bitnami/Openldap 2.6.6`.
 
 Due to #115, the chart does not fully support scaling the `openldap` cluster. To scale the cluster please follow [scaling your cluster](#scaling-your-cluster)
+
 - This will be fixed in priority
 
 ## Prerequisites Details
-* Kubernetes 1.8+
-* PV support on the underlying infrastructure
+
+- Kubernetes 1.8+
+- PV support on the underlying infrastructure
 
 ## Chart Details
+
 This chart will do the following:
 
-* Instantiate 3 instances of OpenLDAP server with multi-master replication
-* A phpldapadmin to administrate the OpenLDAP server
-* ltb-passwd for self service password
+- Instantiate 3 instances of OpenLDAP server with multi-master replication
+- A phpldapadmin to administrate the OpenLDAP server
+- ltb-passwd for self service password
 
 ## TL;DR
 
 To install the chart with the release name `my-release`:
 
 ```bash
-$ helm repo add helm-openldap https://jp-gouin.github.io/helm-openldap/
-$ helm install my-release helm-openldap/openldap-stack-ha
+helm repo add helm-openldap https://jp-gouin.github.io/helm-openldap/
+helm install my-release helm-openldap/openldap-stack-ha
 ```
-
-
 
 ## Configuration
 
@@ -46,128 +49,129 @@ The following table lists the configurable parameters of the openldap chart and 
 
 Global parameters to configure the deployment of the application.
 
-| Parameter                          | Description                                                                                                                               | Default             |
-| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
-| `global.imageRegistry`                     | Global image registry                                                                                                                        | `""`                 |
-| `global.imagePullSecrets`                     | Global list of imagePullSecrets                                                                                                                        | `[]`                 |
-| `global.ldapDomain`                     | Domain LDAP can be explicit `dc=example,dc=org` or domain based `example.org`                                                                                                                         | `example.org`                 |
-| `global.existingSecret`                     | Use existing secret for credentials - the expected keys are LDAP_ADMIN_PASSWORD and LDAP_CONFIG_ADMIN_PASSWORD                                         | `""`                |
-| `global.adminUser`                     | Openldap database admin user                                                                                                                        | `admin`                 |
-| `global.adminPassword`                     | Administration password of Openldap                                                                                                                        | `Not@SecurePassw0rd`                 |
-| `global.configUserEnabled`                     |  Whether to create a configuration admin user                                                                                                                       | `true`                 |
-| `global.configUser`                     |  Openldap configuration admin user                                                                                                                       | `admin`                 |
-| `global.configPassword`                     | Configuration password of Openldap                                                                                                                        | `Not@SecurePassw0rd`                 |
-| `global.ldapPort`                     | Ldap port                                                                                                                         | `389`                 |
-| `global.sslLdapPort`                     | Ldaps port                                                                                                                         | `636`                 |
+| Parameter                  | Description                                                                                                    | Default              |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------- | -------------------- |
+| `global.imageRegistry`     | Global image registry                                                                                          | `""`                 |
+| `global.imagePullSecrets`  | Global list of imagePullSecrets                                                                                | `[]`                 |
+| `global.ldapDomain`        | Domain LDAP can be explicit `dc=example,dc=org` or domain based `example.org`                                  | `example.org`        |
+| `global.existingSecret`    | Use existing secret for credentials - the expected keys are LDAP_ADMIN_PASSWORD and LDAP_CONFIG_ADMIN_PASSWORD | `""`                 |
+| `global.adminUser`         | Openldap database admin user                                                                                   | `admin`              |
+| `global.adminPassword`     | Administration password of Openldap                                                                            | `Not@SecurePassw0rd` |
+| `global.configUserEnabled` | Whether to create a configuration admin user                                                                   | `true`               |
+| `global.configUser`        | Openldap configuration admin user                                                                              | `admin`              |
+| `global.configPassword`    | Configuration password of Openldap                                                                             | `Not@SecurePassw0rd` |
+| `global.ldapPort`          | Ldap port                                                                                                      | `389`                |
+| `global.sslLdapPort`       | Ldaps port                                                                                                     | `636`                |
 
 ### Application parameters
 
 Parameters related to the configuration of the application.
 
-| Parameter                          | Description                                                                                                                               | Default             |
-| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
-| `replicaCount`                     | Number of replicas                                                                                                                        | `3`                 |
-| `users`          | User list to create (comma separated list) , can't be use with customLdifFiles | "" |
-| `userPasswords`          | User password to create (comma seprated list)  | "" |
-| `group`          | Group to create and add list of user above | "" |
-| `env`                              | List of key value pairs as env variables to be sent to the docker image. See https://github.com/bitnami/containers/tree/main/bitnami/openldap for available ones | `[see values.yaml]` |
-| `initTLSSecret.tls_enabled`                      | Set to enable TLS/LDAPS with custom certificate - Please also set `initTLSSecret.secret`, otherwise it will not take effect                                                                                    | `false`             |
-| `initTLSSecret.secret`                       | Secret containing TLS cert and key must contain the keys tls.key , tls.crt and ca.crt                                                                       | `""`                |
-| `customSchemaFiles` | Custom openldap schema files used in addition to default schemas                                                                    | `""`                |
-| `customLdifFiles`                       | Custom openldap configuration files used to override default settings                                                                      | `""`                |
-| `customLdifCm`                       | Existing configmap with custom ldif. Can't be use with customLdifFiles                                                            | `""`                |
-| `customAcls`                       | Custom openldap ACLs. Overrides default ones.                                                                      | `""`                |
-| `replication.enabled`              | Enable the multi-master replication | `true` |
-| `replication.retry`              | retry period for replication in sec | `60` |
-| `replication.timeout`              | timeout for replication  in sec| `1` |
-| `replication.starttls`              | starttls replication | `critical` |
-| `replication.tls_reqcert`              | tls certificate validation for replication | `never` |
-| `replication.interval`             | interval for replication | `00:00:00:10` |
-| `replication.clusterName`          | Set the clustername for replication | "cluster.local" |
+| Parameter                   | Description                                                                                                                                                      | Default             |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `replicaCount`              | Number of replicas                                                                                                                                               | `3`                 |
+| `users`                     | User list to create (comma separated list) , can't be use with customLdifFiles                                                                                   | ""                  |
+| `userPasswords`             | User password to create (comma seprated list)                                                                                                                    | ""                  |
+| `group`                     | Group to create and add list of user above                                                                                                                       | ""                  |
+| `env`                       | List of key value pairs as env variables to be sent to the docker image. See https://github.com/bitnami/containers/tree/main/bitnami/openldap for available ones | `[see values.yaml]` |
+| `initTLSSecret.tls_enabled` | Set to enable TLS/LDAPS with custom certificate - Please also set `initTLSSecret.secret`, otherwise it will not take effect                                      | `false`             |
+| `initTLSSecret.secret`      | Secret containing TLS cert and key must contain the keys tls.key , tls.crt and ca.crt                                                                            | `""`                |
+| `extraSchemaFiles`          | Extra openldap schema files used in addition to default schemas                                                                                                  | `""`                |
+| `customSchemaFiles`         | Custom openldap schema files used in addition to default schemas                                                                                                 | `""`                |
+| `customLdifFiles`           | Custom openldap configuration files used to override default settings                                                                                            | `""`                |
+| `customLdifCm`              | Existing configmap with custom ldif. Can't be use with customLdifFiles                                                                                           | `""`                |
+| `customAcls`                | Custom openldap ACLs. Overrides default ones.                                                                                                                    | `""`                |
+| `replication.enabled`       | Enable the multi-master replication                                                                                                                              | `true`              |
+| `replication.retry`         | retry period for replication in sec                                                                                                                              | `60`                |
+| `replication.timeout`       | timeout for replication  in sec                                                                                                                                  | `1`                 |
+| `replication.starttls`      | starttls replication                                                                                                                                             | `critical`          |
+| `replication.tls_reqcert`   | tls certificate validation for replication                                                                                                                       | `never`             |
+| `replication.interval`      | interval for replication                                                                                                                                         | `00:00:00:10`       |
+| `replication.clusterName`   | Set the clustername for replication                                                                                                                              | "cluster.local"     |
 
 ### Phpladadmin configuration
 
 Parameters related to PHPLdapAdmin
 
-| Parameter                          | Description                                                                                                                               | Default             |
-| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
-| `phpldapadmin.enabled`             | Enable the deployment of PhpLdapAdmin | `true`|
-| `phpldapadmin.ingress`             | Ingress of Phpldapadmin | `{}` |
-| `phpldapadmin.env`  | Environment variables for PhpldapAdmin| `{PHPLDAPADMIN_LDAP_CLIENT_TLS_REQCERT: "never"}` |
+| Parameter              | Description                            | Default                                           |
+| ---------------------- | -------------------------------------- | ------------------------------------------------- |
+| `phpldapadmin.enabled` | Enable the deployment of PhpLdapAdmin  | `true`                                            |
+| `phpldapadmin.ingress` | Ingress of Phpldapadmin                | `{}`                                              |
+| `phpldapadmin.env`     | Environment variables for PhpldapAdmin | `{PHPLDAPADMIN_LDAP_CLIENT_TLS_REQCERT: "never"}` |
 
-For more advance configuration see [README.md](./advanced_examples/README.md)  
+For more advance configuration see [README.md](./advanced_examples/README.md)
 For all possible chart parameters see chart's [README.md](./charts/phpldapadmin/README.md)
 
 ### Self-service password configuration
 
 Parameters related to Self-service password.
 
-| Parameter                          | Description                                                                                                                               | Default             |
-| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
-|`ltb-passwd.enabled`| Enable the deployment of Ltb-Passwd| `true` |
-|`ltb-passwd.ingress`| Ingress of the Ltb-Passwd service | `{}` |
+| Parameter            | Description                         | Default |
+| -------------------- | ----------------------------------- | ------- |
+| `ltb-passwd.enabled` | Enable the deployment of Ltb-Passwd | `true`  |
+| `ltb-passwd.ingress` | Ingress of the Ltb-Passwd service   | `{}`    |
 
-For more advance configuration see [README.md](./advanced_examples/README.md)  
+For more advance configuration see [README.md](./advanced_examples/README.md)
 For all possible parameters see chart's [README.md](./charts/ltb-passwd/README.md)
 
 ### Kubernetes parameters
 
 Parameters related to Kubernetes.
 
-| Parameter                          | Description                                                                                                                               | Default             |
-| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
-| `updateStrategy`                   | StatefulSet update strategy                                                                                                               | `{}`                |
-| `kubeVersion`                 | kubeVersion Override Kubernetes version                                                                                                                | `""`   |
-| `nameOverride`                        | String to partially override common.names.fullname                                                                                                                       | `""`            |
-| `fullnameOverride`                 | fullnameOverride String to fully override common.names.fullname                                                                                                                     | `""`      |
-| `commonLabels`                      | commonLabels Labels to add to all deployed objects                                                                                                            | `{}`                |
-| `clusterDomain`                   | clusterDomain Kubernetes cluster domain name                                                                                                             | `cluster.local`                |
-| `extraDeploy`                   | extraDeploy Array of extra objects to deploy with the release                                                                                | `""`                |
-| `service.annotations`              | Annotations to add to the service                                                                                                         | `{}`                |
-| `service.externalIPs`              | Service external IP addresses                                                                                                             | `[]`                |
-| `service.enableLdapPort`                 | Enable LDAP port on the service and headless service                                                                                | `true`              |
-| `service.enableSslLdapPort`                 | Enable SSL LDAP port on the service and headless service                                                                         | `true`              |
-| `service.ldapPortNodePort`                 | Nodeport of External service port for LDAP if service.type is NodePort                                                                                                            | `nil`               |
-| `service.loadBalancerIP`           | IP address to assign to load balancer (if supported)                                                                                      | `""`                |
-| `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported)                                                                           | `[]`                |
-| `service.sslLdapPortNodePort`                 | Nodeport of External service port for SSL if service.type is NodePort                                                                                                            | `nil`               |
-| `service.type`                     | Service type can be ClusterIP, NodePort, LoadBalancer                                                                                                                              | `ClusterIP`         |
-| `persistence.enabled`              | Whether to use PersistentVolumes or not                                                                                                   | `false`             |
-| `persistence.storageClass`         | Storage class for PersistentVolumes.                                                                                                      | `<unset>`           |
-| `persistence.existingClaim`        | Add existing Volumes Claim. | `<unset>`           |
-| `persistence.accessMode`           | Access mode for PersistentVolumes                                                                                                         | `ReadWriteOnce`     |
-| `persistence.size`                 | PersistentVolumeClaim storage size                                                                                                        | `8Gi`               |
-| `extraVolumes`                     | Allow add extra volumes which could be mounted to statefulset | None |
-| `extraVolumeMounts`                | Add extra volumes to statefulset | None |
-| `customReadinessProbe`                    | Liveness probe configuration                                                                                                              | `[see values.yaml]` |
-| `customLivenessProbe`                   | Readiness probe configuration                                                                                                             | `[see values.yaml]` |
-| `customStartupProbe`                     | Startup probe configuration                                                                                                               | `[see values.yaml]` |
-| `resources`                        | Container resource requests and limits in yaml                                                                                            | `{}`                |
-| `podSecurityContext`              | Enabled OPENLDAP  pods' Security Context | `true` |``
-| `containerSecurityContext`              | Set OPENLDAP  pod's Security Context fsGroup | `true` |
-| `existingConfigmap`              | existingConfigmap The name of an existing ConfigMap with your custom configuration for OPENLDAP  | `` |
-| `podLabels`              | podLabels Extra labels for OPENLDAP  pods| `{}` |
-| `podAnnotations`              | podAnnotations Extra annotations for OPENLDAP  pods | `{}` |
-| `podAffinityPreset`              | podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`| `` |
-| `podAntiAffinityPreset`              | podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `soft` |
-| `pdb.enabled`                      | Enable Pod Disruption Budget                                                                                                              | `false`             |
-| `pdb.minAvailable`                 | Configure PDB to have at least this many health replicas.                                                                                 | `1`                 |
-| `pdb.maxUnavailable`               | Configure PDB to have at most this many unhealth replicas.                                                                                | `<unset>`           |
-| `nodeAffinityPreset`              | nodeAffinityPreset.type Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `true` |
-| `affinity`              | affinity Affinity for OPENLDAP  pods assignment | `` |
-| `nodeSelector`              | nodeSelector Node labels for OPENLDAP  pods assignment | `` |
-| `sidecars`              | sidecars Add additional sidecar containers to the OPENLDAP  pod(s) | `` |
-| `initContainers`              | initContainers Add additional init containers to the OPENLDAP  pod(s) | `` |
-| `volumePermissions`              | 'volumePermissions' init container parameters | `` |
-| `priorityClassName`              | OPENLDAP pods' priority class name | `` |
-| `tolerations`              | Tolerations for pod assignment | [] |
+| Parameter                          | Description                                                                                                       | Default             |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `updateStrategy`                   | StatefulSet update strategy                                                                                       | `{}`                |
+| `kubeVersion`                      | kubeVersion Override Kubernetes version                                                                           | `""`                |
+| `nameOverride`                     | String to partially override common.names.fullname                                                                | `""`                |
+| `fullnameOverride`                 | fullnameOverride String to fully override common.names.fullname                                                   | `""`                |
+| `commonLabels`                     | commonLabels Labels to add to all deployed objects                                                                | `{}`                |
+| `clusterDomain`                    | clusterDomain Kubernetes cluster domain name                                                                      | `cluster.local`     |
+| `extraDeploy`                      | extraDeploy Array of extra objects to deploy with the release                                                     | `""`                |
+| `service.annotations`              | Annotations to add to the service                                                                                 | `{}`                |
+| `service.externalIPs`              | Service external IP addresses                                                                                     | `[]`                |
+| `service.enableLdapPort`           | Enable LDAP port on the service and headless service                                                              | `true`              |
+| `service.enableSslLdapPort`        | Enable SSL LDAP port on the service and headless service                                                          | `true`              |
+| `service.ldapPortNodePort`         | Nodeport of External service port for LDAP if service.type is NodePort                                            | `nil`               |
+| `service.loadBalancerIP`           | IP address to assign to load balancer (if supported)                                                              | `""`                |
+| `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported)                                                   | `[]`                |
+| `service.sslLdapPortNodePort`      | Nodeport of External service port for SSL if service.type is NodePort                                             | `nil`               |
+| `service.type`                     | Service type can be ClusterIP, NodePort, LoadBalancer                                                             | `ClusterIP`         |
+| `persistence.enabled`              | Whether to use PersistentVolumes or not                                                                           | `false`             |
+| `persistence.storageClass`         | Storage class for PersistentVolumes.                                                                              | `<unset>`           |
+| `persistence.existingClaim`        | Add existing Volumes Claim.                                                                                       | `<unset>`           |
+| `persistence.accessMode`           | Access mode for PersistentVolumes                                                                                 | `ReadWriteOnce`     |
+| `persistence.size`                 | PersistentVolumeClaim storage size                                                                                | `8Gi`               |
+| `extraVolumes`                     | Allow add extra volumes which could be mounted to statefulset                                                     | None                |
+| `extraVolumeMounts`                | Add extra volumes to statefulset                                                                                  | None                |
+| `customReadinessProbe`             | Liveness probe configuration                                                                                      | `[see values.yaml]` |
+| `customLivenessProbe`              | Readiness probe configuration                                                                                     | `[see values.yaml]` |
+| `customStartupProbe`               | Startup probe configuration                                                                                       | `[see values.yaml]` |
+| `resources`                        | Container resource requests and limits in yaml                                                                    | `{}`                |
+| `podSecurityContext`               | Enabled OPENLDAP  pods' Security Context                                                                          | `true`              | `` |
+| `containerSecurityContext`         | Set OPENLDAP  pod's Security Context fsGroup                                                                      | `true`              |
+| `existingConfigmap`                | existingConfigmap The name of an existing ConfigMap with your custom configuration for OPENLDAP                   | ``                  |
+| `podLabels`                        | podLabels Extra labels for OPENLDAP  pods                                                                         | `{}`                |
+| `podAnnotations`                   | podAnnotations Extra annotations for OPENLDAP  pods                                                               | `{}`                |
+| `podAffinityPreset`                | podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`             | ``                  |
+| `podAntiAffinityPreset`            | podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`    | `soft`              |
+| `pdb.enabled`                      | Enable Pod Disruption Budget                                                                                      | `false`             |
+| `pdb.minAvailable`                 | Configure PDB to have at least this many health replicas.                                                         | `1`                 |
+| `pdb.maxUnavailable`               | Configure PDB to have at most this many unhealth replicas.                                                        | `<unset>`           |
+| `nodeAffinityPreset`               | nodeAffinityPreset.type Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `true`              |
+| `affinity`                         | affinity Affinity for OPENLDAP  pods assignment                                                                   | ``                  |
+| `nodeSelector`                     | nodeSelector Node labels for OPENLDAP  pods assignment                                                            | ``                  |
+| `sidecars`                         | sidecars Add additional sidecar containers to the OPENLDAP  pod(s)                                                | ``                  |
+| `initContainers`                   | initContainers Add additional init containers to the OPENLDAP  pod(s)                                             | ``                  |
+| `volumePermissions`                | 'volumePermissions' init container parameters                                                                     | ``                  |
+| `priorityClassName`                | OPENLDAP pods' priority class name                                                                                | ``                  |
+| `tolerations`                      | Tolerations for pod assignment                                                                                    | []                  |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install --name my-release -f values.yaml stable/openldap
+helm install --name my-release -f values.yaml stable/openldap
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
@@ -182,7 +186,8 @@ Setup the env part of the configuration to access the OpenLdap server
 **Note** : The ldap host should match the following `namespace.Appfullname`
 
 Example :
-```
+
+```yaml
 phpldapadmin:
   enabled: true
   ingress:
@@ -198,7 +203,9 @@ phpldapadmin:
     PHPLDAPADMIN_LDAP_CLIENT_TLS_REQCERT: "never"
 
 ```
+
 ## Self-service-password
+
 To enable Self-service-password set `ltb-passwd.enabled`  to `true`
 
 Ingress can be configure if you want to expose the service.
@@ -210,7 +217,8 @@ Set `bindDN` accordingly to your ldap domain
 **Note** : The ldap server host should match the following `ldap://namespace.Appfullname`
 
 Example :
-```
+
+```yaml
 ltb-passwd:
   enabled : true
   ingress:
@@ -229,7 +237,7 @@ Deleting the Deployment will not delete associated Persistent Volumes if persist
 Do the following after deleting the chart release to clean up orphaned Persistent Volumes.
 
 ```bash
-$ kubectl delete pvc -l release=${RELEASE-NAME}
+kubectl delete pvc -l release=${RELEASE-NAME}
 ```
 
 ## Custom Secret
@@ -238,24 +246,28 @@ $ kubectl delete pvc -l release=${RELEASE-NAME}
 
 ## Scaling your cluster
 In order to scale the cluster, first use `helm` to updrgade the number of `replica`
-```
+
+```bash
 helm upgrade -n openldap-ha --set replicaCount=4 openldap-ha .
 ```
-Then connect to the `<openldap>-0` container, under `/opt/bitnami/openldap/etc/schema/`, edit :
- 1. `serverid.ldif` and remove existing `olcServerID` (only keep the one you added by scaling)
- 2. `brep.ldif` and remove existing `olcServerID` (only keep the one you added by scaling)
- 3. Apply your changes
 
-```
+Then connect to the `<openldap>-0` container, under `/opt/bitnami/openldap/etc/schema/`, edit :
+
+1. `serverid.ldif` and remove existing `olcServerID` (only keep the one you added by scaling)
+2. `brep.ldif` and remove existing `olcServerID` (only keep the one you added by scaling)
+3. Apply your changes
+
+```bash
 ldapmodify -Y EXTERNAL -H ldapi:/// -f /tmp/serverid.ldif
 ldapmodify -Y EXTERNAL -H ldapi:/// -f /tmp/brep.ldif
 ```
 
 Tips : to edit in the container, use :
-```
+
+```bash
 cat <<EOF > /tmp/serverid.ldif
 copy
-your 
+your
 line
 EOF
 ```
@@ -270,7 +282,7 @@ Valid log levels can be found [here](https://www.openldap.org/doc/admin24/slapdc
 
 **Warning** when using custom ldif in the `customLdifFiles` or `customLdifCm` section you  have to create the high level object `organization`
 
-```
+```ldif
 dn: dc=test,dc=example
 dc: test
 o: Example Inc.

--- a/advanced_examples/MemberOf.md
+++ b/advanced_examples/MemberOf.md
@@ -1,12 +1,12 @@
 # Examples of MemberOf configuration
 
-## Enable MemberOf 
+## Enable MemberOf
 
 Use the following values to enable `memberof` attribute:
 
 This configuration works regardless of the `replication` configuration (`enabled` or `disabled`)
 
-```
+```ldif
 # Default configuration for openldap as environment variables. These get injected directly in the container.
 # Use the env variables from https://github.com/osixia/docker-openldap#beginner-guide
 env:
@@ -45,7 +45,7 @@ customLdifFiles:
     objectclass: posixGroup
     objectclass: top
     add: memberUid
-    memberUid: jdupond    
+    memberUid: jdupond
   03-test-memberof.ldif: |-
     dn: ou=Group,dc=example,dc=org
     objectclass: organizationalUnit
@@ -63,7 +63,7 @@ customLdifFiles:
     objectclass: groupOfNames
     cn: testgroup
     member: uid=test1,ou=People,dc=example,dc=org
-customSchemaFiles:
+extraSchemaFiles:
   #enable memberOf ldap search functionality, users automagically track groups they belong to
   00-memberof.ldif: |-
     # Load memberof module
@@ -83,11 +83,13 @@ customSchemaFiles:
 
 Connect to your openldap instance and execute:
 
-```
+```bash
 LDAPTLS_REQCERT=never ldapsearch -x -D 'cn=admin,dc=example,dc=org' -w Not@SecurePassw0rd -H ldaps://127.0.0.1:1636 -b 'dc=example,dc=org' "(memberOf=cn=testgroup,ou=Group,dc=example,dc=org)"
 ```
-You should get the following result: 
-```
+
+You should get the following result:
+
+```ldif
 # extended LDIF
 #
 # LDAPv3

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -89,7 +89,7 @@ Generate olcSyncRepl list
 {{- define "olcSyncRepls2" -}}
 {{- $name := (include "openldap.fullname" .) }}
 {{- $domain := (include "global.baseDomain" .) }}
-{{- $bindDNUser := .Values.global.adminUser }} 
+{{- $bindDNUser := .Values.global.adminUser }}
 {{- $namespace := .Release.Namespace }}
 {{- $cluster := .Values.replication.clusterName }}
 {{- $adminPassword := ternary .Values.global.adminPassword "%%ADMIN_PASSWORD%%" (empty .Values.global.existingSecret) }}
@@ -186,9 +186,9 @@ Cannot return list => return string comma separated
 Return the list of custom schema files to use
 Cannot return list => return string comma separated
 */}}
-{{- define "openldap.customSchemaFiles" -}}
+{{- define "openldap.extraSchemaFiles" -}}
   {{- $schemas := "" -}}
-  {{- $schemas := ((join "," (.Values.customSchemaFiles | keys | sortAlpha))  | replace ".ldif" "") -}}
+  {{- $schemas := ((join "," (.Values.extraSchemaFiles | keys | sortAlpha))  | replace ".ldif" "") -}}
   {{- print $schemas -}}
 {{- end -}}
 
@@ -198,7 +198,7 @@ Cannot return list => return string comma separated
 */}}
 {{- define "openldap.schemaFiles" -}}
   {{- $schemas := (include "openldap.builtinSchemaFiles" .) -}}
-  {{- $custom_schemas := (include "openldap.customSchemaFiles" .) -}}
+  {{- $custom_schemas := (include "openldap.extraSchemaFiles" .) -}}
   {{- if gt (len $custom_schemas) 0 -}}
     {{- $schemas = print $schemas "," $custom_schemas  -}}
   {{- end -}}

--- a/templates/configmap-extraschema.yaml
+++ b/templates/configmap-extraschema.yaml
@@ -1,0 +1,23 @@
+#
+# A ConfigMap spec for openldap slapd that map directly to files under
+# /opt/bitnami/openldap/etc/schema/custom
+#
+{{- if .Values.extraSchemaFiles }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "openldap.fullname" . }}-extraschema
+  labels:
+    app: {{ template "openldap.name" . }}
+    chart: {{ template "openldap.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels | indent 4 }}
+{{- end }}
+data:
+{{- range $key, $val := .Values.extraSchemaFiles }}
+  {{ $key }}: |-
+{{ $val | indent 4}}
+{{- end }}
+{{- end }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -33,6 +33,12 @@ spec:
         {{- if .Values.customLdifFiles}}
         checksum/configmap-customldif: {{ include (print $.Template.BasePath "/configmap-customldif.yaml") . | sha256sum }}
         {{- end }}
+        {{- if .Values.extraSchemaFiles}}
+        checksum/configmap-extraschema: {{ include (print $.Template.BasePath "/configmap-extraschema.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.customSchemaFiles}}
+        checksum/configmap-customschema: {{ include (print $.Template.BasePath "/configmap-customschema.yaml") . | sha256sum }}
+        {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: {{ template "openldap.fullname" . }}
         release: {{ .Release.Name }}
@@ -52,12 +58,15 @@ spec:
               if [ "$host" = "{{ template "openldap.fullname" . }}-0" ]
               then
                 echo "This is the main openldap so let's init all additional schemas and ldifs here"
-                cp -p -f /cm-schemas-acls/*.ldif /custom_config/ 
-                if [ -d /cm-schemas ]; then
-                  cp -p -f /cm-schemas/*.ldif /custom-schemas/ 
+                cp -p -f /cm-schemas-acls/*.ldif /custom_config/
+                if [ -d /cm-extra-schemas ]; then
+                  cp -p -f /cm-extra-schemas/*.ldif /extra-schemas/
+                fi
+                if [ -d /cm-custom-schemas ]; then
+                  cp -p -f /cm-custom-schemas/*.ldif /custom-schemas/
                 fi
                 if [ -d /cm-ldifs ]; then
-                  cp -p -f /cm-ldifs/*.ldif /custom-ldifs/ 
+                  cp -p -f /cm-ldifs/*.ldif /custom-ldifs/
                 fi
               else
                 cp -p -f /cm-schemas-acls/*.ldif /custom_config/
@@ -74,14 +83,20 @@ spec:
           resources: {{- toYaml .Values.initTLSSecret.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
-    {{- if .Values.customSchemaFiles }}
-      {{- range $file := (include "openldap.customSchemaFiles" . | split ",") }}
-            - name: cm-custom-schema-files
-              mountPath: /cm-schemas/{{ $file }}.ldif
+    {{- if .Values.extraSchemaFiles }}
+      {{- range $file := (include "openldap.extraSchemaFiles" . | split ",") }}
+            - name: cm-extra-schema-files
+              mountPath: /cm-extra-schemas/{{ $file }}.ldif
               subPath: {{ $file }}.ldif
       {{- end }}
+            - name: extra-schema-files
+              mountPath: /extra-schemas/
+    {{- end }}
+    {{- if .Values.customSchemaFiles }}
+            - name: cm-custom-schema-files
+              mountPath: /cm-schemas
             - name: custom-schema-files
-              mountPath: /custom-schemas/
+              mountPath: /custom-schemas
     {{- end }}
     {{- if or (.Values.customLdifFiles) (.Values.customLdifCm) }}
             - name: cm-custom-ldif-files
@@ -141,7 +156,7 @@ spec:
             - mountPath: /bitnami
               name: data
       {{- end }}
-    
+
       serviceAccountName: {{ template "openldap.serviceAccountName" . }}
       {{- include "openldap.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.hostAliases }}
@@ -252,16 +267,20 @@ spec:
               mountPath: /opt/bitnami/openldap/etc/schema/{{ $file }}.ldif
               subPath: {{ $file }}.ldif
             {{- end }}
-{{- if .Values.customSchemaFiles}}
-            {{- range $file := (include "openldap.customSchemaFiles" . | split ",") }}
-            - name: custom-schema-files
+{{- if .Values.extraSchemaFiles}}
+            {{- range $file := (include "openldap.extraSchemaFiles" . | split ",") }}
+            - name: extra-schema-files
               mountPath: /opt/bitnami/openldap/etc/schema/{{ $file }}.ldif
               subPath: {{ $file }}.ldif
             {{- end }}
 {{- end }}
+{{- if .Values.customSchemaFiles}}
+            - name: custom-schema-files
+              mountPath: /schemas # default value for LDAP_CUSTOM_SCHEMA_DIR, see https://github.com/bitnami/containers/blob/c969cdc2e0d547f67f89b7e4a21bc2e00716f6ab/bitnami/openldap/2.6/debian-12/rootfs/opt/bitnami/scripts/libopenldap.sh#L42
+{{- end }}
 {{- if or (.Values.customLdifFiles) (.Values.customLdifCm) }}
             - name: custom-ldif-files
-              mountPath: /ldifs/
+              mountPath: /ldifs # default value for LDAP_CUSTOM_LDIF_DIR, see https://github.com/bitnami/containers/blob/c969cdc2e0d547f67f89b7e4a21bc2e00716f6ab/bitnami/openldap/2.6/debian-
 {{- end }}
 {{- range .Values.customFileSets }}
 {{- $fs := . }}
@@ -304,6 +323,14 @@ spec:
           configMap:
             name: {{ .Values.customLdifCm }}
         - name: custom-ldif-files
+          emptyDir:
+            medium: Memory
+{{- end }}
+{{- if .Values.extraSchemaFiles }}
+        - name: cm-extra-schema-files
+          configMap:
+            name: {{ template "openldap.fullname" . }}-extraschema
+        - name: extra-schema-files
           emptyDir:
             medium: Memory
 {{- end }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -94,7 +94,7 @@ spec:
     {{- end }}
     {{- if .Values.customSchemaFiles }}
             - name: cm-custom-schema-files
-              mountPath: /cm-schemas
+              mountPath: /cm-custom-schemas
             - name: custom-schema-files
               mountPath: /custom-schemas
     {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -66,7 +66,7 @@ image:
 logLevel: info
 
 initSchema:
-  image: 
+  image:
     repository: debian
     tag: latest
     pullPolicy: Always
@@ -98,13 +98,12 @@ service:
 # Use the env variables from https://hub.docker.com/r/bitnami/openldap/
 # Be careful, do not modify the following values unless you know exactly what your are doing
 env:
- BITNAMI_DEBUG: "true"
- LDAP_LOGLEVEL: "256"
- LDAP_TLS_ENFORCE: "false"
- LDAPTLS_REQCERT: "never"
- LDAP_ENABLE_TLS: "yes"
- LDAP_SKIP_DEFAULT_TREE: "no"
-
+  BITNAMI_DEBUG: "true"
+  LDAP_LOGLEVEL: "256"
+  LDAP_TLS_ENFORCE: "false"
+  LDAPTLS_REQCERT: "never"
+  LDAP_ENABLE_TLS: "yes"
+  LDAP_SKIP_DEFAULT_TREE: "no"
 
 # Pod Disruption Budget for Stateful Set
 # Disabled by default, to ensure backwards compatibility
@@ -122,12 +121,20 @@ pdb:
 # userPasswords: bitnami1, bitnami2
 
 ## Group to create and add list of user above
-  ## Default set by bitnami image
+## Default set by bitnami image
 # group: readers
 
 # Custom openldap schema files used to be used in addition to default schemas
 # Note that the supplied files are sorted by name and inserted into 'LDAP_EXTRA_SCHEMAS' env var
 # after chart default schemas, allowing you to control the loading sequence.
+# extraSchemaFiles:
+#   custom.ldif: |-
+#     # custom schema
+#   anothercustom.ldif: |-
+#     # another custom schema
+
+# Custom openldap schema files used to be used in addition to default schemas
+# Note that the supplied schema files are imported in order of their filename
 # customSchemaFiles:
 #   custom.ldif: |-
 #     # custom schema
@@ -383,7 +390,7 @@ serviceAccount:
   automountServiceAccountToken: false
   ## @param serviceAccount.annotations Additional custom annotations for the ServiceAccount
   ##
-  annotations: {}  
+  annotations: {}
 
 ## @section Init Container Parameters
 
@@ -409,7 +416,7 @@ initTLSSecret:
     ##
     pullPolicy: IfNotPresent
   # The name of a kubernetes.io/tls type secret to use for TLS
-  secret: "" 
+  secret: ""
   ## init-tls-secret container's resource requests and limits
   ## ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   ## @param initTlsSecret.resources.limits The resources limits for the init container
@@ -444,8 +451,8 @@ volumePermissions:
     tag: 10-debian-10
     pullPolicy: IfNotPresent
 
-  ## Command to execute during the volumePermission startup
-    command: [ 'sh', '-c', 'chmod -R g+rwX /bitnami' ]
+    ## Command to execute during the volumePermission startup
+    command: ["sh", "-c", "chmod -R g+rwX /bitnami"]
   ## command: {}
   ## Init container's resource requests and limits
   ## ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -476,7 +483,6 @@ updateReplication:
     ##   memory: 1Gi
     limits: {}
     requests: {}
-
 
 ## Configure extra options for liveness, readiness, and startup probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
@@ -512,7 +518,7 @@ test:
 ## ltb-passwd
 # For more parameters check following file: ./charts/ltb-passwd/values.yaml
 ltb-passwd:
-  enabled : true
+  enabled: true
   image:
     tag: 5.2.3
   ingress:
@@ -524,19 +530,19 @@ ltb-passwd:
     pathType: Prefix
     ## Ingress Host
     hosts:
-    - "ssl-ldap2.example"
+      - "ssl-ldap2.example"
     ## Ingress cert
     tls: []
     # - secretName: ssl-ldap2.example
     #   hosts:
     #   - ssl-ldap2.example
   # ldap:
-    # if you want to restrict search base tree for users instead of complete domain
-    # searchBase: "ou=....,dc=mydomain,dc=com"
-    # if you want to use a dedicated bindDN for the search with less permissions instead of cn=admin one
-    # bindDN: "cn=....,dc=mydomain,dc=com"
-    # if you want to use a specific key of the credentials secret instead of the default one (LDAP_ADMIN_PASSWORD)
-    # passKey: LDAP_MY_KEY
+  # if you want to restrict search base tree for users instead of complete domain
+  # searchBase: "ou=....,dc=mydomain,dc=com"
+  # if you want to use a dedicated bindDN for the search with less permissions instead of cn=admin one
+  # bindDN: "cn=....,dc=mydomain,dc=com"
+  # if you want to use a specific key of the credentials secret instead of the default one (LDAP_ADMIN_PASSWORD)
+  # passKey: LDAP_MY_KEY
 
 ## phpldapadmin
 ## For more parameters check following file: ./charts/phpldapadmin/values.yaml
@@ -555,7 +561,7 @@ phpldapadmin:
     pathType: Prefix
     ## Ingress Host
     hosts:
-    - phpldapadmin.example
+      - phpldapadmin.example
     ## Ingress cert
     tls: []
     # - secretName: phpldapadmin.example

--- a/values.yaml
+++ b/values.yaml
@@ -124,17 +124,30 @@ pdb:
 ## Default set by bitnami image
 # group: readers
 
-# Custom openldap schema files used to be used in addition to default schemas
+# Custom openldap schema files used to be used in addition to default schemas (cosine, inetorgperson, nis)
 # Note that the supplied files are sorted by name and inserted into 'LDAP_EXTRA_SCHEMAS' env var
 # after chart default schemas, allowing you to control the loading sequence.
+# Unlike customSchemaFiles, extraSchemaFiles allows loading of modules.
 # extraSchemaFiles:
-#   custom.ldif: |-
-#     # custom schema
-#   anothercustom.ldif: |-
-#     # another custom schema
+#   memberof.ldif: |-
+#     # Load memberof module
+#     dn: cn=module,cn=config
+#     cn: module
+#     objectClass: olcModuleList
+#     olcModuleLoad: memberof
+#     olcModulePath: /opt/bitnami/openldap/lib/openldap
+#
+#     dn: olcOverlay=memberof,olcDatabase={2}mdb,cn=config
+#     changetype: add
+#     objectClass: olcOverlayConfig
+#     objectClass: olcMemberOf
+#     olcOverlay: memberof
+#     olcMemberOfRefint: TRUE
 
 # Custom openldap schema files used to be used in addition to default schemas
 # Note that the supplied schema files are imported in order of their filename
+# From the Bitnami documentation:
+# <...> custom internal schema files that could not be added as custom ldif files (i.e. containing some structuralObjectClass).
 # customSchemaFiles:
 #   custom.ldif: |-
 #     # custom schema


### PR DESCRIPTION
### What this PR does / why we need it:

The current `customSchemaFiles` option does a schema import via `LDAP_EXTRA_SCHEMAS`.
I renamed this current behavior to `extraSchemaFiles`. It's done via `ldapadd` while slapd is running.

I added a new `customSchemaFiles` option that imports schemas via `LDAP_CUSTOM_SCHEMA_DIR`.
It's done via `slapadd` while slapd is stopped.

Since the new `customSchemaFiles` option does not support all schemas that could be set via the current `customSchemaFiles` option, **this change is not backwards compatible**. The migration should be easy though because one just needs to use the `extraSchemaFiles` option instead.

Related issues:
- I wanted to fix #104, but the core problem of it was actually fixed in #161
- duplicates #129

### Pre-submission checklist:

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you updated the readme?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss open a ticket first**