### PR TITLE
Add possibility to define static clusterIp for service

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Parameters related to Kubernetes.
 | `service.enableLdapPort`                 | Enable LDAP port on the service and headless service                                                                                | `true`              |
 | `service.enableSslLdapPort`                 | Enable SSL LDAP port on the service and headless service                                                                         | `true`              |
 | `service.ldapPortNodePort`                 | Nodeport of External service port for LDAP if service.type is NodePort                                                                                                            | `nil`               |
+| `service.clusterIP`                 | Static cluster IP to assign to the service (if supported)                                                            | `nil`              |
 | `service.loadBalancerIP`           | IP address to assign to load balancer (if supported)                                                                                      | `""`                |
 | `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported)                                                                           | `[]`                |
 | `service.sslLdapPortNodePort`                 | Nodeport of External service port for SSL if service.type is NodePort                                                                                                            | `nil`               |

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -23,6 +23,9 @@ spec:
   {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{ toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
+  {{- if and (eq .Values.service.type "ClusterIP") .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
   ports:
     {{- if .Values.service.enableLdapPort }}
     - name: ldap-port

--- a/values.yaml
+++ b/values.yaml
@@ -89,6 +89,8 @@ service:
   ##
   externalIPs: []
 
+  ## Define a static clusterIP
+  #clusterIP:
   #loadBalancerIP:
   #loadBalancerSourceRanges: []
   type: ClusterIP


### PR DESCRIPTION
### What this PR does / why we need it:
Allows a user to define a static IP for the service when the service type is clusterIP

Fix #168 