### PR TITLE
Quote LDAP_PASSWORDS that may begin with special characters

### DIFF
--- a/templates/configmap-env.yaml
+++ b/templates/configmap-env.yaml
@@ -23,7 +23,7 @@ data:
   LDAP_USERS: {{ .Values.users }}
   {{- end }}
   {{- if .Values.userPasswords }}
-  LDAP_PASSWORDS: {{ .Values.userPasswords }}
+  LDAP_PASSWORDS: "{{ .Values.userPasswords }}"
   {{- end }}
   {{- if .Values.group }}
   LDAP_GROUP: {{ .Values.group }}


### PR DESCRIPTION
### What this PR does / why we need it:

Previously breaking with msg: chart openldap-stack-ha@4.2.2: YAML parse error on openldap-stack-ha/templates/configmap-env.yaml: error converting YAML to JSON: yaml: line 20: found character that cannot start any token

See https://stackoverflow.com/a/22235064/1484823 for special characters requiring quotes

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you updated the readme? N/A
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss open a ticket first** Yes