### PR TITLE
add command to openldap container

### DIFF
--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -182,22 +182,6 @@ spec:
           {{- if .Values.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
-          command:
-            - sh
-            - -c
-            - |
-              host=$(hostname)
-              if [ "$host" = "{{ template "openldap.fullname" . }}-0" ]
-              then
-                echo "This is the first openldap pod so let's init all additional schemas and ldifs here"
-              else
-                echo "This is not the first openldap pod so let's not init anything"
-                unset LDAP_CONFIGURE_PPOLICY LDAP_PPOLICY_HASH_CLEARTEXT
-                export LDAP_SKIP_DEFAULT_TREE=yes
-              fi
-
-              /opt/bitnami/scripts/openldap/entrypoint.sh /opt/bitnami/scripts/openldap/run.sh
-   
           env:
             - name: LDAP_EXTRA_SCHEMAS
               value: {{ print "cosine,inetorgperson,nis," (include "openldap.schemaFiles" (dict "context" . )) }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -177,6 +177,22 @@ spec:
           {{- if .Values.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
+          command:
+            - sh
+            - -c
+            - |
+              host=$(hostname)
+              if [ "$host" = "{{ template "openldap.fullname" . }}-0" ]
+              then
+                echo "This is the first openldap pod so let's init all additional schemas and ldifs here"
+              else
+                echo "This is not the first openldap pod so let's not init anything"
+                unset LDAP_CONFIGURE_PPOLICY LDAP_PPOLICY_HASH_CLEARTEXT
+                export LDAP_SKIP_DEFAULT_TREE=yes
+              fi
+
+              /opt/bitnami/scripts/openldap/entrypoint.sh /opt/bitnami/scripts/openldap/run.sh
+   
           env:
             - name: POD_NAME
               valueFrom:

--- a/values.yaml
+++ b/values.yaml
@@ -302,7 +302,21 @@ containerSecurityContext:
 existingConfigmap:
 ## @param command Override default container command (useful when using custom images)
 ##
-command: []
+command:
+  - sh
+  - -c
+  - |
+    host=$(hostname)
+    if [ "$host" = "{{ template "openldap.fullname" . }}-0" ]
+    then
+      echo "This is the first openldap pod so let's init all additional schemas and ldifs here"
+    else
+      echo "This is not the first openldap pod so let's not init anything"
+      unset LDAP_CONFIGURE_PPOLICY LDAP_PPOLICY_HASH_CLEARTEXT
+      export LDAP_SKIP_DEFAULT_TREE=yes
+    fi
+
+    exec /opt/bitnami/scripts/openldap/entrypoint.sh
 ## @param args Override default container args (useful when using custom images)
 ##
 args: []

--- a/values.yaml
+++ b/values.yaml
@@ -307,7 +307,7 @@ command:
   - -c
   - |
     host=$(hostname)
-    if [ "$host" = "{{ template "openldap.fullname" . }}-0" ]
+    if [[ "$host" = *-0 ]]
     then
       echo "This is the first openldap pod so let's init all additional schemas and ldifs here"
     else

--- a/values.yaml
+++ b/values.yaml
@@ -307,15 +307,15 @@ command:
   - -c
   - |
     host=$(hostname)
-    if [[ "$host" = *-0 ]]
-    then
-      echo "This is the first openldap pod so let's init all additional schemas and ldifs here"
-    else
-      echo "This is not the first openldap pod so let's not init anything"
-      unset LDAP_CONFIGURE_PPOLICY LDAP_PPOLICY_HASH_CLEARTEXT
-      export LDAP_SKIP_DEFAULT_TREE=yes
-    fi
-
+    case "$host" in
+      *"-0") 
+        echo "This is the first openldap pod so let's init all additional schemas and ldifs here" ;;
+      *)
+        echo "This is not the first openldap pod so let's not init anything"
+        unset LDAP_CONFIGURE_PPOLICY LDAP_PPOLICY_HASH_CLEARTEXT
+        export LDAP_SKIP_DEFAULT_TREE=yes ;;
+    esac
+    
     exec /opt/bitnami/scripts/openldap/entrypoint.sh
 ## @param args Override default container args (useful when using custom images)
 ##


### PR DESCRIPTION
this command ensures non-first openldap containers dont try to init already initialized cluster-wide resources, such as the root DN or ppolicy module.

- more detail: https://github.com/jp-gouin/helm-openldap/issues/148#issuecomment-2338435733

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you updated the readme?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss open a ticket first**