### PR TITLE
Support ipFamilyPolicy

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Parameters related to Kubernetes.
 | `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported)                                                                           | `[]`                |
 | `service.sslLdapPortNodePort`      | Nodeport of External service port for SSL if service.type is NodePort                                                                     | `nil`               |
 | `service.type`                     | Service type can be ClusterIP, NodePort, LoadBalancer                                                                                     | `ClusterIP`         |
+| `service.ipFamilyPolicy`           | Represents the dual-stack-ness requested or required by this Service.                                                                     | `SingleStack`       |
 | `persistence.enabled`              | Whether to use PersistentVolumes or not                                                                                                   | `false`             |
 | `persistence.storageClass`         | Storage class for PersistentVolumes.                                                                                                      | `<unset>`           |
 | `persistence.existingClaim`        | Add existing Volumes Claim.                                                                                                               | `<unset>`           |

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -17,6 +17,7 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
   {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -96,6 +96,12 @@ service:
   type: ClusterIP
   sessionAffinity: None
 
+  ## Represents the dual-stack-ness requested or required by this Service. Possible values are
+  ## SingleStack, PreferDualStack or RequireDualStack.
+  ## The ipFamilies and clusterIPs fields depend on the value of this field.
+  ## Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/
+  ipFamilyPolicy: SingleStack
+
 # Default configuration for openldap as environment variables. These get injected directly in the container.
 # Use the env variables from https://hub.docker.com/r/bitnami/openldap/
 # Be careful, do not modify the following values unless you know exactly what your are doing


### PR DESCRIPTION
### What this PR does / why we need it:
Deployments function well in a dual-stack configuration, yet there seems to be no method to configure the ipFamilyPolicy as either "PreferDualStack" or "RequireDualStack."

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you updated the readme?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss open a ticket first**