### PR TITLE
Fix cacert --> reqcert typo

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -76,7 +76,7 @@ Generate olcServerID list
 {{- define "openldap.replication.tls_reqcert" -}}
 {{- if .Values.initTLSSecret.tls_enabled -}}
   {{- if .Values.replication.tls_reqcert -}}
-    {{- printf "tls_cacert=%s" .Values.replication.tls_reqcert -}}
+    {{- printf "tls_reqcert=%s" .Values.replication.tls_reqcert -}}
   {{- else }}
     {{- printf "tls_reqcert=demand" -}}
   {{- end -}}


### PR DESCRIPTION
There's a typo in the _helpers.tpl when setting tls_reqcert value. The **tls_cacert** is used instead of  **tls_reqcert** which results in the following config:
```
olcSyncrepl: {0}rid=101 provider=ldap://ldap-0.ldap-headless.openldap.svc.clus
 ter.local:1389 binddn=xxx bindmethod=simple credentials
 =xxxx searchbase=o=xxx type=refreshAndPersist interval=00:00:00:10 net
 work-timeout=0 retry="60 +" timeout=1 starttls=critical tls_cacert=never tls_
 cacert=/opt/bitnami/openldap/certs/ca.crt
```

setting **tls_cacert=never** and leaving out  **tls_reqcert** completely
