### PR TITLE
add support for externalTrafficPolicy on service

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Parameters related to Kubernetes.
 | `service.type`                             | Service type can be ClusterIP, NodePort, LoadBalancer                                                             | `ClusterIP`         |
 | `service.sslLdapPortNodePort`              | Nodeport of External service port for SSL if service.type is NodePort                                             | `nil`               |
 | `service.ipFamilyPolicy`                   | Represents the dual-stack-ness requested or required by this Service.                                             | `SingleStack`       |
+| `service.externalTrafficPolicy`            | Sets the externalTrafficPolicy for this Service.                                                                  | `Cluster`           |
 | `serviceReadOnly.annotations`              | Annotations to add to the service                                                                                 | `{}`                |
 | `serviceReadOnly.externalIPs`              | Service external IP addresses                                                                                     | `[]`                |
 | `serviceReadOnly.enableLdapPort`           | Enable LDAP port on the service and headless service                                                              | `true`              |
@@ -149,6 +150,7 @@ Parameters related to Kubernetes.
 | `serviceReadOnly.sslLdapPortNodePort`      | Nodeport of External service port for SSL if service.type is NodePort                                             | `nil`               |
 | `serviceReadOnly.type`                     | Service type can be ClusterIP, NodePort, LoadBalancer                                                             | `ClusterIP`         |
 | `serviceReadOnly.ipFamilyPolicy`                   | Represents the dual-stack-ness requested or required by this Service.                                             | `SingleStack`       |
+| `serviceReadOnly.externalTrafficPolicy`    | Sets the externalTrafficPolicy for this Service.                                                                  | `Cluster`           |
 | `persistence.enabled`                      | Whether to use PersistentVolumes or not                                                                           | `false`             |
 | `persistence.storageClass`                 | Storage class for PersistentVolumes.                                                                              | `<unset>`           |
 | `persistence.existingClaim`                | Add existing Volumes Claim.                                                                                       | `<unset>`           |

--- a/templates/service-readonly.yaml
+++ b/templates/service-readonly.yaml
@@ -52,6 +52,7 @@ spec:
       {{- end }}
     {{- end }}
   sessionAffinity: {{ .Values.service.sessionAffinity }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   selector:
     app.kubernetes.io/component: {{ template "openldap.fullname" . }}-readonly
     release: {{ .Release.Name }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -51,6 +51,7 @@ spec:
       {{- end }}
     {{- end }}
   sessionAffinity: {{ .Values.service.sessionAffinity }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   selector:
     app.kubernetes.io/component: {{ template "openldap.fullname" . }}
     release: {{ .Release.Name }}

--- a/values.yaml
+++ b/values.yaml
@@ -97,6 +97,7 @@ service:
   #loadBalancerSourceRanges: []
   type: ClusterIP
   sessionAffinity: None
+  externalTrafficPolicy: Cluster
 
   ## Represents the dual-stack-ness requested or required by this Service. Possible values are
   ## SingleStack, PreferDualStack or RequireDualStack.
@@ -130,6 +131,7 @@ serviceReadOnly:
   #loadBalancerSourceRanges: []
   type: ClusterIP
   sessionAffinity: None
+  externalTrafficPolicy: Cluster
 
   ## Represents the dual-stack-ness requested or required by this Service. Possible values are
   ## SingleStack, PreferDualStack or RequireDualStack.


### PR DESCRIPTION
### What this PR does / why we need it:
This adds support for the externalTrafficPolicy setting for the service resources. Setting externalTrafficPolicy to local preserves the client ip for the pod (https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip)

I don't think this fixes any open issues, but it resolves an issue I have this helm chart (Client IPs are not preserved for purposes of logging device accessing ldap through the loadbalancer service)

### Pre-submission checklist:

* [ X ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ X ] Have you updated the readme?
* [ X ] Is this PR backward compatible? **If it is not backward compatible, please discuss open a ticket first**