### PR TITLE
fix(init-schema): escape special characters in sed secret substitutions

### DIFF
--- a/templates/statefulset-readonly.yaml
+++ b/templates/statefulset-readonly.yaml
@@ -46,17 +46,27 @@ spec:
           image: {{ include "openldap.initSchemaImage" . }}
           imagePullPolicy: {{ .Values.initSchema.image.pullPolicy | quote }}
           command:
-            - sh
+            - bash
             - -c
             - |
-              cp -p -f /cm-schemas-acls/*.ldif /custom_config/ 
+              cp -p -f /cm-schemas-acls/*.ldif /custom_config/
               if [ -d /cm-schemas ]; then
-                cp -p -f /cm-schemas/*.ldif /custom-schemas/ 
+                cp -p -f /cm-schemas/*.ldif /custom-schemas/
               fi
               echo "let the replication takes care of everything :)"
             {{- if .Values.global.existingSecret }}
-              sed -i -e "s/%%CONFIG_PASSWORD%%/${LDAP_CONFIG_ADMIN_PASSWORD}/g" /custom_config/*
-              sed -i -e "s/%%ADMIN_PASSWORD%%/${LDAP_ADMIN_PASSWORD}/g" /custom_config/*
+              CONFIG_ADMIN_PASSWORD="${LDAP_CONFIG_ADMIN_PASSWORD//\\/\\\\}"
+              CONFIG_ADMIN_PASSWORD="${CONFIG_ADMIN_PASSWORD//\//\\\/}"
+              CONFIG_ADMIN_PASSWORD="${CONFIG_ADMIN_PASSWORD//\//\\\/}"
+              CONFIG_ADMIN_PASSWORD="${CONFIG_ADMIN_PASSWORD//&/\\&}"
+
+              ADMIN_PASSWORD="${LDAP_ADMIN_PASSWORD//\\/\\\\}"
+              ADMIN_PASSWORD="${ADMIN_PASSWORD//\//\\\/}"
+              ADMIN_PASSWORD="${ADMIN_PASSWORD//\//\\\/}"
+              ADMIN_PASSWORD="${ADMIN_PASSWORD//&/\\&}"
+
+              sed -i -e "s/%%CONFIG_PASSWORD%%/${CONFIG_ADMIN_PASSWORD}/g" /custom_config/*
+              sed -i -e "s/%%ADMIN_PASSWORD%%/${ADMIN_PASSWORD}/g" /custom_config/*
             {{- end }}
           {{- if .Values.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
@@ -132,7 +142,7 @@ spec:
             - mountPath: /bitnami
               name: data
       {{- end }}
-    
+
       serviceAccountName: {{ template "openldap.serviceAccountName" . }}
       {{- include "openldap.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.hostAliases }}
@@ -178,7 +188,7 @@ spec:
                   fieldPath: metadata.name
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
-            {{- end }}         
+            {{- end }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}
             - configMapRef:

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -45,7 +45,7 @@ spec:
           image: {{ include "openldap.initSchemaImage" . }}
           imagePullPolicy: {{ .Values.initSchema.image.pullPolicy | quote }}
           command:
-            - sh
+            - bash
             - -c
             - |
               host=$(hostname)
@@ -64,8 +64,16 @@ spec:
                 echo "let the replication takes care of everything :)"
               fi
             {{- if .Values.global.existingSecret }}
-              sed -i -e "s/%%CONFIG_PASSWORD%%/${LDAP_CONFIG_ADMIN_PASSWORD}/g" /custom_config/*
-              sed -i -e "s/%%ADMIN_PASSWORD%%/${LDAP_ADMIN_PASSWORD}/g" /custom_config/*
+              CONFIG_ADMIN_PASSWORD="${LDAP_CONFIG_ADMIN_PASSWORD//\\/\\\\}"
+              CONFIG_ADMIN_PASSWORD="${CONFIG_ADMIN_PASSWORD//\//\\\/}"
+              CONFIG_ADMIN_PASSWORD="${CONFIG_ADMIN_PASSWORD//&/\\&}"
+
+              ADMIN_PASSWORD="${LDAP_ADMIN_PASSWORD//\\/\\\\}"
+              ADMIN_PASSWORD="${ADMIN_PASSWORD//\//\\\/}"
+              ADMIN_PASSWORD="${ADMIN_PASSWORD//&/\\&}"
+
+              sed -i -e "s/%%CONFIG_PASSWORD%%/${CONFIG_ADMIN_PASSWORD}/g" /custom_config/*
+              sed -i -e "s/%%ADMIN_PASSWORD%%/${ADMIN_PASSWORD}/g" /custom_config/*
             {{- end }}
           {{- if .Values.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. --> open issue, please link to the issue here. -->
This patch adds substitution of the `/`, `&` and `\` characters in the `sed` commands in order to escape and allow such characters in the passwords provided by `existingSecret`. 

This is done by using `bash` instead of `sh` in order to use `bash` substitutions for each of the special characters before interpolating the replacement string in the `sed` commands.

Should fix #70 .

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you updated the readme?
* [x] Is this PR backward compatible?