### PR TITLE
Support existing shared PVC

### DIFF
--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -140,6 +140,9 @@ spec:
           volumeMounts:
             - mountPath: /bitnami
               name: data
+              {{- if and .Values.persistence.existingClaim .Values.persistence.subPath }}
+              subPath: {{ .Values.persistence.subPath }}
+              {{- end }}
       {{- end }}
       serviceAccountName: {{ template "openldap.serviceAccountName" . }}
       {{- include "openldap.imagePullSecrets" . | nindent 6 }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -259,6 +259,9 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /bitnami/openldap/
+              {{- if and .Values.persistence.existingClaim .Values.persistence.subPath }}
+              subPath: {{ .Values.persistence.subPath }}/openldap
+              {{- end }}
             - name: certs
               mountPath: /opt/bitnami/openldap/certs
             {{- range $file :=  (include "openldap.builtinSchemaFiles" (dict "context" . ) | split ",") }}

--- a/values.yaml
+++ b/values.yaml
@@ -261,6 +261,7 @@ persistence:
   ##
   # storageClass: "standard-singlewriter"
   # existingClaim: openldap-pvc
+  # subPath: openldap #Used for shared existingClaim pvc
   accessModes:
     - ReadWriteOnce
   size: 8Gi

--- a/values.yaml
+++ b/values.yaml
@@ -419,6 +419,20 @@ sidecars: {}
 ##    imagePullPolicy: Always
 ##    command: ['sh', '-c', 'echo "hello world"']
 ##
+## If you are using shared pvc with subPath, you will need to add initContainers to do chown and chmod on the share point. 
+## Here is an example:
+## initContainers:
+##   - name: shared-pvc-volume
+##     image: docker.io/bitnami/os-shell:latest
+##     command: ['sh', '-c', 'mkdir -p /bitnami/openldap; chown -R 1001:1001 /bitnami; chmod -R g+rwX /bitnami']
+##     securityContext:
+##       runAsUser: 0
+##       runAsGroup: 0
+##       fsGroup: 0
+##     volumeMounts:
+##       - name: data
+##         mountPath: /bitnami
+##         subPath: enter-your-subpath-here
 initContainers: {}
 
 ## Service Account


### PR DESCRIPTION
### What this PR does / why we need it:
Added support for subPath to be used with existingClaim, which is needed when shared PVC is being used in single self-hosted kubernetes cluster.
To use this feature, set the following in values.yaml:
1. persistence.existingClaim and persistence.subPath
2. initContainer section.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you updated the readme? No relevant section to update.
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss open a ticket first**